### PR TITLE
Add configurable ONNX provider selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ pip install "onnxruntime-gpu<1.27" nvidia-cudnn-cu12 nvidia-cuda-runtime-cu12
 ```
 
 Avoid installing both `onnxruntime` and `onnxruntime-gpu` in the same
-environment.
+environment. CollectorVision warns when both distributions are present because
+they provide the same `onnxruntime` Python module and can hide GPU providers.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,13 @@ runtime in an environment with compatible drivers:
 pip install "collectorvision[gpu] @ git+https://github.com/HanClinto/CollectorVision.git"
 ```
 
-The Linux GPU extra currently pins `onnxruntime-gpu<1.27` because the 1.27
-wheels require CUDA 13 runtime libraries, while CUDA 12 remains common.
+The default `gpu` extra intentionally allows the latest ONNX Runtime GPU wheel.
+If you are on a CUDA 12 Linux system and the latest wheel requires newer CUDA
+runtime libraries, use the CUDA-12 compatibility extra instead:
+
+```bash
+pip install "collectorvision[gpu-cu12] @ git+https://github.com/HanClinto/CollectorVision.git"
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,20 @@ Experimental javascript port version hosted here: https://hanclinto.github.io/Co
 > **Not yet on PyPI.** Install directly from GitHub:
 
 ```bash
-uv pip install "collectorvision[cpu] @ git+https://github.com/HanClinto/CollectorVision.git"
+uv pip install git+https://github.com/HanClinto/CollectorVision.git
+uv pip install onnxruntime
 ```
 
 Or with plain `pip`:
 
 ```bash
-pip install "collectorvision[cpu] @ git+https://github.com/HanClinto/CollectorVision.git"
+pip install git+https://github.com/HanClinto/CollectorVision.git
+pip install onnxruntime
 ```
 
-Requires Python 3.10+. No GPU required — inference runs on CPU via ONNX Runtime.
+Requires Python 3.10+. Neural inference requires an ONNX Runtime backend. Add
+exactly one backend package to your environment, `requirements.txt`, or
+`pyproject.toml`: use `onnxruntime` for CPU or `onnxruntime-gpu` for NVIDIA GPU.
 
 ### Hardware acceleration
 
@@ -44,20 +48,22 @@ back to CPU. `provider="gpu"` means "use an accelerated ONNX Runtime provider"
 and works with whatever accelerator provider ONNX Runtime exposes on the current
 machine, such as CoreML, CUDA, DirectML, or ROCm.
 
-If your platform needs a separate accelerator runtime, install the optional GPU
-runtime in an environment with compatible drivers:
+For GPU acceleration, replace the CPU backend with a GPU backend that matches
+your machine:
 
 ```bash
-pip install "collectorvision[gpu] @ git+https://github.com/HanClinto/CollectorVision.git"
+pip install onnxruntime-gpu
 ```
 
-The default `gpu` extra intentionally allows the latest ONNX Runtime GPU wheel.
-If you are on a CUDA 12 Linux system and the latest wheel requires newer CUDA
-runtime libraries, use the CUDA-12 compatibility extra instead:
+ONNX Runtime GPU package compatibility depends on your CUDA runtime. For example,
+some CUDA 12 Linux systems need:
 
 ```bash
-pip install "collectorvision[gpu-cu12] @ git+https://github.com/HanClinto/CollectorVision.git"
+pip install "onnxruntime-gpu<1.27" nvidia-cudnn-cu12 nvidia-cuda-runtime-cu12
 ```
+
+Avoid installing both `onnxruntime` and `onnxruntime-gpu` in the same
+environment.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,19 @@ cvg.NeuralCornerDetector(provider="auto")  # default: accelerator if available, 
 cvg.NeuralEmbedder(provider="auto")
 
 cvg.NeuralEmbedder(provider="cpu")         # force CPU
-cvg.NeuralEmbedder(provider="cuda")        # require CUDA, error if unavailable
+cvg.NeuralEmbedder(provider="gpu")         # require acceleration, error if unavailable
 ```
 
 The default `provider="auto"` prefers installed accelerator providers and falls
-back to CPU. For CUDA, install the optional GPU runtime in an environment with
-compatible NVIDIA drivers:
+back to CPU. `provider="gpu"` means "use an accelerated ONNX Runtime provider"
+and works with whatever accelerator provider ONNX Runtime exposes on the current
+machine, such as CoreML, CUDA, DirectML, or ROCm.
+
+If your platform needs a separate accelerator runtime, install the optional GPU
+runtime in an environment with compatible drivers:
 
 ```bash
-pip install "collectorvision[cuda] @ git+https://github.com/HanClinto/CollectorVision.git"
+pip install "collectorvision[gpu] @ git+https://github.com/HanClinto/CollectorVision.git"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ runtime in an environment with compatible drivers:
 pip install "collectorvision[gpu] @ git+https://github.com/HanClinto/CollectorVision.git"
 ```
 
+The Linux GPU extra currently pins `onnxruntime-gpu<1.27` because the 1.27
+wheels require CUDA 13 runtime libraries, while CUDA 12 remains common.
+
 ---
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ pip install git+https://github.com/HanClinto/CollectorVision.git
 
 Requires Python 3.10+. No GPU required — inference runs on CPU via ONNX Runtime.
 
+### Hardware acceleration
+
+CollectorVision uses ONNX Runtime providers through a small, simple API:
+
+```python
+cvg.NeuralCornerDetector(provider="auto")  # default: accelerator if available, then CPU
+cvg.NeuralEmbedder(provider="auto")
+
+cvg.NeuralEmbedder(provider="cpu")         # force CPU
+cvg.NeuralEmbedder(provider="cuda")        # require CUDA, error if unavailable
+```
+
+The default `provider="auto"` prefers installed accelerator providers and falls
+back to CPU. For CUDA, install the optional GPU runtime in an environment with
+compatible NVIDIA drivers:
+
+```bash
+pip install "collectorvision[cuda] @ git+https://github.com/HanClinto/CollectorVision.git"
+```
+
 ---
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Experimental javascript port version hosted here: https://hanclinto.github.io/Co
 > **Not yet on PyPI.** Install directly from GitHub:
 
 ```bash
-uv pip install git+https://github.com/HanClinto/CollectorVision.git
+uv pip install "collectorvision[cpu] @ git+https://github.com/HanClinto/CollectorVision.git"
 ```
 
 Or with plain `pip`:
 
 ```bash
-pip install git+https://github.com/HanClinto/CollectorVision.git
+pip install "collectorvision[cpu] @ git+https://github.com/HanClinto/CollectorVision.git"
 ```
 
 Requires Python 3.10+. No GPU required — inference runs on CPU via ONNX Runtime.

--- a/collector_vision/detectors/neural.py
+++ b/collector_vision/detectors/neural.py
@@ -1,6 +1,6 @@
 """NeuralCornerDetector — ONNX-based learned card corner detector (Cornelius).
 
-Runs entirely on CPU via onnxruntime — no PyTorch dependency required.
+Runs through ONNX Runtime providers — no PyTorch dependency required.
 
 Architecture: MobileViT-XXS backbone + SimCC coordinate heads trained on
 CCG card corners.  Input 384×384 RGB, outputs four normalised (x, y) corner
@@ -30,6 +30,7 @@ import cv2
 import numpy as np
 
 from collector_vision.interfaces import DetectionResult
+from collector_vision.onnx_providers import Provider, create_inference_session
 
 _IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
 _IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
@@ -83,6 +84,10 @@ class NeuralCornerDetector:
         Minimum ``sigmoid(presence_logit)`` to treat a detection as valid.
     num_threads:
         Number of intra-op threads for onnxruntime.  Defaults to 4.
+    provider:
+        ONNX Runtime provider preference. ``"auto"`` prefers available
+        accelerators and falls back to CPU; use ``"cpu"`` or ``"cuda"`` to force
+        one path.
     """
 
     def __init__(
@@ -90,6 +95,7 @@ class NeuralCornerDetector:
         checkpoint: str | Path | None = None,
         presence_threshold: float = 0.5,
         num_threads: int = 4,
+        provider: Provider = "auto",
     ) -> None:
         from collector_vision import weights as _w
 
@@ -104,21 +110,17 @@ class NeuralCornerDetector:
 
         self._presence_threshold = presence_threshold
         self._sess, self._input_name, self._input_size, self._has_sharpness = self._load(
-            checkpoint, num_threads
+            checkpoint, num_threads, provider
         )
 
     @staticmethod
-    def _load(onnx_path: Path, num_threads: int):
+    def _load(onnx_path: Path, num_threads: int, provider: Provider):
         import onnxruntime as ort
 
         opts = ort.SessionOptions()
         opts.intra_op_num_threads = num_threads
         opts.inter_op_num_threads = 1
-        sess = ort.InferenceSession(
-            str(onnx_path),
-            sess_options=opts,
-            providers=["CPUExecutionProvider"],
-        )
+        sess = create_inference_session(onnx_path, opts, provider)
         input_meta = sess.get_inputs()[0]
         input_name = input_meta.name
         shape = input_meta.shape

--- a/collector_vision/detectors/neural.py
+++ b/collector_vision/detectors/neural.py
@@ -86,7 +86,7 @@ class NeuralCornerDetector:
         Number of intra-op threads for onnxruntime.  Defaults to 4.
     provider:
         ONNX Runtime provider preference. ``"auto"`` prefers available
-        accelerators and falls back to CPU; use ``"cpu"`` or ``"cuda"`` to force
+        accelerators and falls back to CPU; use ``"cpu"`` or ``"gpu"`` to force
         one path.
     """
 

--- a/collector_vision/detectors/neural.py
+++ b/collector_vision/detectors/neural.py
@@ -115,12 +115,7 @@ class NeuralCornerDetector:
 
     @staticmethod
     def _load(onnx_path: Path, num_threads: int, provider: Provider):
-        import onnxruntime as ort
-
-        opts = ort.SessionOptions()
-        opts.intra_op_num_threads = num_threads
-        opts.inter_op_num_threads = 1
-        sess = create_inference_session(onnx_path, opts, provider)
+        sess = create_inference_session(onnx_path, num_threads, provider)
         input_meta = sess.get_inputs()[0]
         input_name = input_meta.name
         shape = input_meta.shape

--- a/collector_vision/embedders/neural.py
+++ b/collector_vision/embedders/neural.py
@@ -74,12 +74,7 @@ class NeuralEmbedder:
 
     @staticmethod
     def _load(onnx_path: Path, num_threads: int, provider: Provider):
-        import onnxruntime as ort
-
-        opts = ort.SessionOptions()
-        opts.intra_op_num_threads = num_threads
-        opts.inter_op_num_threads = 1
-        sess = create_inference_session(onnx_path, opts, provider)
+        sess = create_inference_session(onnx_path, num_threads, provider)
         input_meta = sess.get_inputs()[0]
         input_name = input_meta.name
         shape = input_meta.shape

--- a/collector_vision/embedders/neural.py
+++ b/collector_vision/embedders/neural.py
@@ -1,6 +1,6 @@
 """NeuralEmbedder — ONNX-based ArcFace card embedder (Milo).
 
-Runs entirely on CPU via onnxruntime — no PyTorch dependency required.
+Runs through ONNX Runtime providers — no PyTorch dependency required.
 
 Architecture: MobileViT-XXS backbone + shared linear projection trained with
 multi-task ArcFace loss (illustration_id + set_code).  Input 448×448 RGB,
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import numpy as np
 from PIL import Image
+
+from collector_vision.onnx_providers import Provider, create_inference_session
 
 _IMAGENET_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
 _IMAGENET_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
@@ -41,6 +43,10 @@ class NeuralEmbedder:
         CollectorVision-Pipeline project, not here).
     num_threads:
         Number of intra-op threads for onnxruntime.
+    provider:
+        ONNX Runtime provider preference. ``"auto"`` prefers available
+        accelerators and falls back to CPU; use ``"cpu"`` or ``"cuda"`` to force
+        one path.
     """
 
     def __init__(
@@ -48,6 +54,7 @@ class NeuralEmbedder:
         checkpoint: str | Path | None = None,
         batch_size: int = 1,
         num_threads: int = 4,
+        provider: Provider = "auto",
     ) -> None:
         from collector_vision import weights as _w
 
@@ -61,20 +68,18 @@ class NeuralEmbedder:
             )
 
         self._batch_size = batch_size
-        self._sess, self._input_name, self._input_size = self._load(checkpoint, num_threads)
+        self._sess, self._input_name, self._input_size = self._load(
+            checkpoint, num_threads, provider
+        )
 
     @staticmethod
-    def _load(onnx_path: Path, num_threads: int):
+    def _load(onnx_path: Path, num_threads: int, provider: Provider):
         import onnxruntime as ort
 
         opts = ort.SessionOptions()
         opts.intra_op_num_threads = num_threads
         opts.inter_op_num_threads = 1
-        sess = ort.InferenceSession(
-            str(onnx_path),
-            sess_options=opts,
-            providers=["CPUExecutionProvider"],
-        )
+        sess = create_inference_session(onnx_path, opts, provider)
         input_meta = sess.get_inputs()[0]
         input_name = input_meta.name
         shape = input_meta.shape

--- a/collector_vision/embedders/neural.py
+++ b/collector_vision/embedders/neural.py
@@ -45,7 +45,7 @@ class NeuralEmbedder:
         Number of intra-op threads for onnxruntime.
     provider:
         ONNX Runtime provider preference. ``"auto"`` prefers available
-        accelerators and falls back to CPU; use ``"cpu"`` or ``"cuda"`` to force
+        accelerators and falls back to CPU; use ``"cpu"`` or ``"gpu"`` to force
         one path.
     """
 

--- a/collector_vision/onnx_providers.py
+++ b/collector_vision/onnx_providers.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Literal
 from warnings import warn
 
-Provider = Literal["auto", "cpu", "cuda"]
+Provider = Literal["auto", "cpu", "gpu"]
 
 _CPU_PROVIDER = "CPUExecutionProvider"
 _CUDA_PROVIDER = "CUDAExecutionProvider"
@@ -22,23 +22,24 @@ def _resolve_provider_names(provider: Provider, available: list[str]) -> list[st
     if provider == "cpu":
         return [_CPU_PROVIDER]
 
-    if provider == "cuda":
-        if _CUDA_PROVIDER not in available:
+    if provider == "gpu":
+        selected = [name for name in _AUTO_ACCELERATORS if name in available]
+        if not selected:
             raise RuntimeError(
-                "CUDA provider was requested, but ONNX Runtime does not report "
-                f"{_CUDA_PROVIDER} as available. Available providers: {available}. "
-                "Install a CUDA-enabled ONNX Runtime package, such as "
-                "`collectorvision[cuda]` or `onnxruntime-gpu`, in an environment "
-                "with compatible NVIDIA drivers."
+                "GPU provider was requested, but ONNX Runtime does not report any "
+                f"accelerator providers as available. Available providers: {available}. "
+                "Install an accelerator-enabled ONNX Runtime package for your platform, "
+                "such as `collectorvision[gpu]` or `onnxruntime-gpu` for NVIDIA CUDA."
             )
-        return [_CUDA_PROVIDER, _CPU_PROVIDER]
+        selected.append(_CPU_PROVIDER)
+        return selected
 
     if provider == "auto":
         selected = [name for name in _AUTO_ACCELERATORS if name in available]
         selected.append(_CPU_PROVIDER)
         return selected
 
-    valid = "', '".join(("auto", "cpu", "cuda"))
+    valid = "', '".join(("auto", "cpu", "gpu"))
     raise ValueError(f"Unknown provider {provider!r}. Expected one of: '{valid}'.")
 
 
@@ -50,7 +51,7 @@ def create_inference_session(
     """Create an ONNX Runtime session with simple provider selection.
 
     ``provider='auto'`` prefers installed accelerator providers, then falls back
-    to CPU. Explicit ``'cpu'`` and ``'cuda'`` requests are respected.
+    to CPU. Explicit ``'cpu'`` and ``'gpu'`` requests are respected.
     """
     import onnxruntime as ort
 

--- a/collector_vision/onnx_providers.py
+++ b/collector_vision/onnx_providers.py
@@ -16,6 +16,11 @@ _AUTO_ACCELERATORS = (
     "DmlExecutionProvider",
     "ROCMExecutionProvider",
 )
+_NVIDIA_PROVIDERS = (_CUDA_PROVIDER, "TensorrtExecutionProvider")
+
+
+def _has_accelerator(providers: list[str]) -> bool:
+    return any(name in _AUTO_ACCELERATORS for name in providers)
 
 
 def _resolve_provider_names(provider: Provider, available: list[str]) -> list[str]:
@@ -66,11 +71,34 @@ def create_inference_session(
     providers = _resolve_provider_names(provider, available)
 
     try:
-        return ort.InferenceSession(
+        if any(name in _NVIDIA_PROVIDERS for name in providers) and hasattr(ort, "preload_dlls"):
+            ort.preload_dlls(cuda=True, cudnn=True)
+
+        sess = ort.InferenceSession(
             str(onnx_path),
             sess_options=sess_options,
             providers=providers,
         )
+        active_providers = list(sess.get_providers())
+        if provider == "gpu" and not _has_accelerator(active_providers):
+            raise RuntimeError(
+                "GPU provider was requested, but ONNX Runtime initialized without "
+                f"an accelerator provider. Requested providers: {providers}. "
+                f"Active providers: {active_providers}."
+            )
+        if (
+            provider == "auto"
+            and _has_accelerator(providers)
+            and not _has_accelerator(active_providers)
+        ):
+            warn(
+                "ONNX Runtime accelerator providers were available but session "
+                f"initialized with CPU only. Requested providers: {providers}. "
+                f"Active providers: {active_providers}.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        return sess
     except Exception as exc:
         if provider != "auto" or providers == [_CPU_PROVIDER]:
             raise

--- a/collector_vision/onnx_providers.py
+++ b/collector_vision/onnx_providers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Literal
 from warnings import warn
@@ -17,6 +18,7 @@ _AUTO_ACCELERATORS = (
     "ROCMExecutionProvider",
 )
 _NVIDIA_PROVIDERS = (_CUDA_PROVIDER, "TensorrtExecutionProvider")
+_WARNED_RUNTIME_CONFLICT = False
 
 
 def _has_accelerator(providers: list[str]) -> bool:
@@ -48,6 +50,38 @@ def _resolve_provider_names(provider: Provider, available: list[str]) -> list[st
     raise ValueError(f"Unknown provider {provider!r}. Expected one of: '{valid}'.")
 
 
+def _installed_onnx_runtime_distributions() -> list[tuple[str, str]]:
+    installed: list[tuple[str, str]] = []
+    for dist_name in ("onnxruntime", "onnxruntime-gpu"):
+        try:
+            installed.append((dist_name, version(dist_name)))
+        except PackageNotFoundError:
+            pass
+    return installed
+
+
+def _warn_if_conflicting_runtimes_installed() -> None:
+    global _WARNED_RUNTIME_CONFLICT
+
+    if _WARNED_RUNTIME_CONFLICT:
+        return
+
+    installed = _installed_onnx_runtime_distributions()
+    if len(installed) <= 1:
+        return
+
+    _WARNED_RUNTIME_CONFLICT = True
+    formatted = ", ".join(f"{name}=={dist_version}" for name, dist_version in installed)
+    warn(
+        "Both ONNX Runtime CPU and GPU distributions are installed "
+        f"({formatted}). These packages provide the same `onnxruntime` Python "
+        "module and can conflict; install exactly one backend, such as "
+        "`onnxruntime` for CPU or `onnxruntime-gpu` for NVIDIA GPU.",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+
+
 def create_inference_session(
     onnx_path: Path,
     num_threads: int,
@@ -74,6 +108,8 @@ def create_inference_session(
             "one of those packages there. Avoid installing both onnxruntime and "
             "onnxruntime-gpu in the same environment."
         ) from exc
+
+    _warn_if_conflicting_runtimes_installed()
 
     opts = ort.SessionOptions()
     opts.intra_op_num_threads = num_threads

--- a/collector_vision/onnx_providers.py
+++ b/collector_vision/onnx_providers.py
@@ -34,7 +34,7 @@ def _resolve_provider_names(provider: Provider, available: list[str]) -> list[st
                 "GPU provider was requested, but ONNX Runtime does not report any "
                 f"accelerator providers as available. Available providers: {available}. "
                 "Install an accelerator-enabled ONNX Runtime package for your platform, "
-                "such as `collectorvision[gpu]` or `onnxruntime-gpu` for NVIDIA CUDA."
+                "such as `onnxruntime-gpu` for NVIDIA CUDA."
             )
         selected.append(_CPU_PROVIDER)
         return selected
@@ -50,7 +50,7 @@ def _resolve_provider_names(provider: Provider, available: list[str]) -> list[st
 
 def create_inference_session(
     onnx_path: Path,
-    sess_options: object,
+    num_threads: int,
     provider: Provider,
 ):
     """Create an ONNX Runtime session with simple provider selection.
@@ -62,10 +62,22 @@ def create_inference_session(
         import onnxruntime as ort
     except ImportError as exc:
         raise ImportError(
-            "CollectorVision neural inference requires an ONNX Runtime package. "
-            "Install `collectorvision[cpu]` for CPU inference or "
-            "`collectorvision[gpu]` for accelerator support."
+            "CollectorVision neural inference requires exactly one ONNX Runtime backend.\n\n"
+            "For CPU inference, install:\n"
+            "  pip install onnxruntime\n"
+            "  uv add onnxruntime\n\n"
+            "For NVIDIA GPU inference, install an ONNX Runtime GPU build that matches "
+            "your CUDA runtime, for example:\n"
+            "  pip install onnxruntime-gpu\n"
+            "  uv add onnxruntime-gpu\n\n"
+            "If you manage dependencies in requirements.txt or pyproject.toml, add "
+            "one of those packages there. Avoid installing both onnxruntime and "
+            "onnxruntime-gpu in the same environment."
         ) from exc
+
+    opts = ort.SessionOptions()
+    opts.intra_op_num_threads = num_threads
+    opts.inter_op_num_threads = 1
 
     available = ort.get_available_providers()
     providers = _resolve_provider_names(provider, available)
@@ -76,7 +88,7 @@ def create_inference_session(
 
         sess = ort.InferenceSession(
             str(onnx_path),
-            sess_options=sess_options,
+            sess_options=opts,
             providers=providers,
         )
         active_providers = list(sess.get_providers())
@@ -111,6 +123,6 @@ def create_inference_session(
         )
         return ort.InferenceSession(
             str(onnx_path),
-            sess_options=sess_options,
+            sess_options=opts,
             providers=[_CPU_PROVIDER],
         )

--- a/collector_vision/onnx_providers.py
+++ b/collector_vision/onnx_providers.py
@@ -53,7 +53,14 @@ def create_inference_session(
     ``provider='auto'`` prefers installed accelerator providers, then falls back
     to CPU. Explicit ``'cpu'`` and ``'gpu'`` requests are respected.
     """
-    import onnxruntime as ort
+    try:
+        import onnxruntime as ort
+    except ImportError as exc:
+        raise ImportError(
+            "CollectorVision neural inference requires an ONNX Runtime package. "
+            "Install `collectorvision[cpu]` for CPU inference or "
+            "`collectorvision[gpu]` for accelerator support."
+        ) from exc
 
     available = ort.get_available_providers()
     providers = _resolve_provider_names(provider, available)

--- a/collector_vision/onnx_providers.py
+++ b/collector_vision/onnx_providers.py
@@ -1,0 +1,80 @@
+"""Small public-to-ONNX provider mapping for neural inference."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+from warnings import warn
+
+Provider = Literal["auto", "cpu", "cuda"]
+
+_CPU_PROVIDER = "CPUExecutionProvider"
+_CUDA_PROVIDER = "CUDAExecutionProvider"
+_AUTO_ACCELERATORS = (
+    _CUDA_PROVIDER,
+    "CoreMLExecutionProvider",
+    "DmlExecutionProvider",
+    "ROCMExecutionProvider",
+)
+
+
+def _resolve_provider_names(provider: Provider, available: list[str]) -> list[str]:
+    if provider == "cpu":
+        return [_CPU_PROVIDER]
+
+    if provider == "cuda":
+        if _CUDA_PROVIDER not in available:
+            raise RuntimeError(
+                "CUDA provider was requested, but ONNX Runtime does not report "
+                f"{_CUDA_PROVIDER} as available. Available providers: {available}. "
+                "Install a CUDA-enabled ONNX Runtime package, such as "
+                "`collectorvision[cuda]` or `onnxruntime-gpu`, in an environment "
+                "with compatible NVIDIA drivers."
+            )
+        return [_CUDA_PROVIDER, _CPU_PROVIDER]
+
+    if provider == "auto":
+        selected = [name for name in _AUTO_ACCELERATORS if name in available]
+        selected.append(_CPU_PROVIDER)
+        return selected
+
+    valid = "', '".join(("auto", "cpu", "cuda"))
+    raise ValueError(f"Unknown provider {provider!r}. Expected one of: '{valid}'.")
+
+
+def create_inference_session(
+    onnx_path: Path,
+    sess_options: object,
+    provider: Provider,
+):
+    """Create an ONNX Runtime session with simple provider selection.
+
+    ``provider='auto'`` prefers installed accelerator providers, then falls back
+    to CPU. Explicit ``'cpu'`` and ``'cuda'`` requests are respected.
+    """
+    import onnxruntime as ort
+
+    available = ort.get_available_providers()
+    providers = _resolve_provider_names(provider, available)
+
+    try:
+        return ort.InferenceSession(
+            str(onnx_path),
+            sess_options=sess_options,
+            providers=providers,
+        )
+    except Exception as exc:
+        if provider != "auto" or providers == [_CPU_PROVIDER]:
+            raise
+
+        warn(
+            "ONNX Runtime accelerator session initialization failed; falling back "
+            f"to CPUExecutionProvider. Original error: {type(exc).__name__}: {exc}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return ort.InferenceSession(
+            str(onnx_path),
+            sess_options=sess_options,
+            providers=[_CPU_PROVIDER],
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,13 @@ cpu = [
 gpu = [
     "onnxruntime>=1.17; platform_system == 'Darwin'",
     "onnxruntime-gpu>=1.17,<1.27; platform_system != 'Darwin'",
+    "nvidia-cuda-runtime-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
+    "nvidia-cudnn-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
 ]
 cuda = [
     "onnxruntime-gpu>=1.17,<1.27; platform_system != 'Darwin'",
+    "nvidia-cuda-runtime-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
+    "nvidia-cudnn-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
 ]
 # Example server
 server = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+gpu = [
+    "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
+]
 cuda = [
     "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,18 +29,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cpu = [
-    "onnxruntime>=1.17",
-]
-gpu = [
-    "onnxruntime>=1.17; platform_system == 'Darwin'",
-    "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
-]
-gpu-cu12 = [
-    "onnxruntime-gpu>=1.17,<1.27; platform_system != 'Darwin'",
-    "nvidia-cuda-runtime-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
-    "nvidia-cudnn-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
-]
 # Example server
 server = [
     "fastapi>=0.110",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cuda = [
+    "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
+]
 # Example server
 server = [
     "fastapi>=0.110",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,17 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "onnxruntime>=1.17",
     "Pillow>=9.0",
     "numpy>=1.24",
     "opencv-python-headless>=4.7",
 ]
 
 [project.optional-dependencies]
+cpu = [
+    "onnxruntime>=1.17",
+]
 gpu = [
+    "onnxruntime>=1.17; platform_system == 'Darwin'",
     "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
 ]
 cuda = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,9 @@ cpu = [
 ]
 gpu = [
     "onnxruntime>=1.17; platform_system == 'Darwin'",
-    "onnxruntime-gpu>=1.17,<1.27; platform_system != 'Darwin'",
-    "nvidia-cuda-runtime-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
-    "nvidia-cudnn-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
+    "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
 ]
-cuda = [
+gpu-cu12 = [
     "onnxruntime-gpu>=1.17,<1.27; platform_system != 'Darwin'",
     "nvidia-cuda-runtime-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",
     "nvidia-cudnn-cu12; platform_system == 'Linux' and platform_machine == 'x86_64'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ cpu = [
 ]
 gpu = [
     "onnxruntime>=1.17; platform_system == 'Darwin'",
-    "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
+    "onnxruntime-gpu>=1.17,<1.27; platform_system != 'Darwin'",
 ]
 cuda = [
-    "onnxruntime-gpu>=1.17; platform_system != 'Darwin'",
+    "onnxruntime-gpu>=1.17,<1.27; platform_system != 'Darwin'",
 ]
 # Example server
 server = [

--- a/tests/test_onnx_providers.py
+++ b/tests/test_onnx_providers.py
@@ -1,0 +1,68 @@
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from collector_vision.onnx_providers import _resolve_provider_names, create_inference_session
+
+
+class ProviderResolutionTests(unittest.TestCase):
+    def test_auto_prefers_available_accelerators_then_cpu(self) -> None:
+        providers = _resolve_provider_names(
+            "auto",
+            ["CPUExecutionProvider", "CoreMLExecutionProvider", "CUDAExecutionProvider"],
+        )
+
+        self.assertEqual(
+            providers,
+            ["CUDAExecutionProvider", "CoreMLExecutionProvider", "CPUExecutionProvider"],
+        )
+
+    def test_cpu_forces_cpu_provider(self) -> None:
+        providers = _resolve_provider_names(
+            "cpu",
+            ["CPUExecutionProvider", "CUDAExecutionProvider"],
+        )
+
+        self.assertEqual(providers, ["CPUExecutionProvider"])
+
+    def test_cuda_requires_cuda_provider(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "CUDA provider was requested"):
+            _resolve_provider_names("cuda", ["CPUExecutionProvider"])
+
+    def test_unknown_provider_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unknown provider"):
+            _resolve_provider_names("magic", ["CPUExecutionProvider"])  # type: ignore[arg-type]
+
+
+class CreateInferenceSessionTests(unittest.TestCase):
+    def test_auto_falls_back_to_cpu_when_accelerator_session_fails(self) -> None:
+        calls: list[list[str]] = []
+
+        class FakeSession:
+            def __init__(self, path, sess_options, providers):  # noqa: ANN001
+                calls.append(list(providers))
+                if providers != ["CPUExecutionProvider"]:
+                    raise RuntimeError("accelerator failed")
+
+        fake_ort = types.SimpleNamespace(
+            get_available_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"],
+            InferenceSession=FakeSession,
+        )
+
+        with mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}):
+            with self.assertWarnsRegex(RuntimeWarning, "falling back"):
+                create_inference_session(Path("model.onnx"), object(), "auto")
+
+        self.assertEqual(
+            calls,
+            [
+                ["CUDAExecutionProvider", "CPUExecutionProvider"],
+                ["CPUExecutionProvider"],
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onnx_providers.py
+++ b/tests/test_onnx_providers.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import collector_vision.onnx_providers as provider_module
 from collector_vision.onnx_providers import _resolve_provider_names, create_inference_session
 
 
@@ -46,6 +47,9 @@ class ProviderResolutionTests(unittest.TestCase):
 
 
 class CreateInferenceSessionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        provider_module._WARNED_RUNTIME_CONFLICT = False
+
     def test_missing_onnxruntime_has_actionable_error(self) -> None:
         real_import = builtins.__import__
 
@@ -120,6 +124,34 @@ class CreateInferenceSessionTests(unittest.TestCase):
         with mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}):
             with self.assertWarnsRegex(RuntimeWarning, "CPU only"):
                 create_inference_session(Path("model.onnx"), 4, "auto")
+
+    def test_conflicting_runtime_distributions_warn_once(self) -> None:
+        class FakeSession:
+            def __init__(self, path, sess_options, providers):  # noqa: ANN001
+                self.providers = list(providers)
+
+            def get_providers(self) -> list[str]:
+                return self.providers
+
+        fake_ort = types.SimpleNamespace(
+            get_available_providers=lambda: ["CPUExecutionProvider"],
+            InferenceSession=FakeSession,
+            SessionOptions=types.SimpleNamespace,
+        )
+
+        with (
+            mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}),
+            mock.patch(
+                "collector_vision.onnx_providers._installed_onnx_runtime_distributions",
+                return_value=[("onnxruntime", "1.27.0"), ("onnxruntime-gpu", "1.26.0")],
+            ),
+        ):
+            with self.assertWarnsRegex(RuntimeWarning, "Both ONNX Runtime"):
+                create_inference_session(Path("model.onnx"), 4, "cpu")
+            with mock.patch("warnings.warn") as warn_mock:
+                create_inference_session(Path("model.onnx"), 4, "cpu")
+
+        warn_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_onnx_providers.py
+++ b/tests/test_onnx_providers.py
@@ -71,6 +71,40 @@ class CreateInferenceSessionTests(unittest.TestCase):
             ],
         )
 
+    def test_gpu_rejects_session_that_silently_falls_back_to_cpu(self) -> None:
+        class FakeSession:
+            def __init__(self, path, sess_options, providers):  # noqa: ANN001
+                self.providers = list(providers)
+
+            def get_providers(self) -> list[str]:
+                return ["CPUExecutionProvider"]
+
+        fake_ort = types.SimpleNamespace(
+            get_available_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"],
+            InferenceSession=FakeSession,
+        )
+
+        with mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}):
+            with self.assertRaisesRegex(RuntimeError, "initialized without an accelerator"):
+                create_inference_session(Path("model.onnx"), object(), "gpu")
+
+    def test_auto_warns_when_session_silently_falls_back_to_cpu(self) -> None:
+        class FakeSession:
+            def __init__(self, path, sess_options, providers):  # noqa: ANN001
+                self.providers = list(providers)
+
+            def get_providers(self) -> list[str]:
+                return ["CPUExecutionProvider"]
+
+        fake_ort = types.SimpleNamespace(
+            get_available_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"],
+            InferenceSession=FakeSession,
+        )
+
+        with mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}):
+            with self.assertWarnsRegex(RuntimeWarning, "CPU only"):
+                create_inference_session(Path("model.onnx"), object(), "auto")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_onnx_providers.py
+++ b/tests/test_onnx_providers.py
@@ -27,9 +27,17 @@ class ProviderResolutionTests(unittest.TestCase):
 
         self.assertEqual(providers, ["CPUExecutionProvider"])
 
-    def test_cuda_requires_cuda_provider(self) -> None:
-        with self.assertRaisesRegex(RuntimeError, "CUDA provider was requested"):
-            _resolve_provider_names("cuda", ["CPUExecutionProvider"])
+    def test_gpu_requires_an_accelerator_provider(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "GPU provider was requested"):
+            _resolve_provider_names("gpu", ["CPUExecutionProvider"])
+
+    def test_gpu_uses_available_accelerators_then_cpu_graph_fallback(self) -> None:
+        providers = _resolve_provider_names(
+            "gpu",
+            ["CPUExecutionProvider", "CoreMLExecutionProvider"],
+        )
+
+        self.assertEqual(providers, ["CoreMLExecutionProvider", "CPUExecutionProvider"])
 
     def test_unknown_provider_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "Unknown provider"):

--- a/tests/test_onnx_providers.py
+++ b/tests/test_onnx_providers.py
@@ -1,3 +1,4 @@
+import builtins
 import sys
 import types
 import unittest
@@ -45,6 +46,18 @@ class ProviderResolutionTests(unittest.TestCase):
 
 
 class CreateInferenceSessionTests(unittest.TestCase):
+    def test_missing_onnxruntime_has_actionable_error(self) -> None:
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):  # noqa: ANN001
+            if name == "onnxruntime":
+                raise ImportError("missing onnxruntime")
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            with self.assertRaisesRegex(ImportError, "pip install onnxruntime"):
+                create_inference_session(Path("model.onnx"), 4, "auto")
+
     def test_auto_falls_back_to_cpu_when_accelerator_session_fails(self) -> None:
         calls: list[list[str]] = []
 
@@ -57,11 +70,12 @@ class CreateInferenceSessionTests(unittest.TestCase):
         fake_ort = types.SimpleNamespace(
             get_available_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"],
             InferenceSession=FakeSession,
+            SessionOptions=types.SimpleNamespace,
         )
 
         with mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}):
             with self.assertWarnsRegex(RuntimeWarning, "falling back"):
-                create_inference_session(Path("model.onnx"), object(), "auto")
+                create_inference_session(Path("model.onnx"), 4, "auto")
 
         self.assertEqual(
             calls,
@@ -82,11 +96,12 @@ class CreateInferenceSessionTests(unittest.TestCase):
         fake_ort = types.SimpleNamespace(
             get_available_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"],
             InferenceSession=FakeSession,
+            SessionOptions=types.SimpleNamespace,
         )
 
         with mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}):
             with self.assertRaisesRegex(RuntimeError, "initialized without an accelerator"):
-                create_inference_session(Path("model.onnx"), object(), "gpu")
+                create_inference_session(Path("model.onnx"), 4, "gpu")
 
     def test_auto_warns_when_session_silently_falls_back_to_cpu(self) -> None:
         class FakeSession:
@@ -99,11 +114,12 @@ class CreateInferenceSessionTests(unittest.TestCase):
         fake_ort = types.SimpleNamespace(
             get_available_providers=lambda: ["CUDAExecutionProvider", "CPUExecutionProvider"],
             InferenceSession=FakeSession,
+            SessionOptions=types.SimpleNamespace,
         )
 
         with mock.patch.dict(sys.modules, {"onnxruntime": fake_ort}):
             with self.assertWarnsRegex(RuntimeWarning, "CPU only"):
-                create_inference_session(Path("model.onnx"), object(), "auto")
+                create_inference_session(Path("model.onnx"), 4, "auto")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #22.

This adds a small provider option to both neural runtime classes:

- `provider="auto"` is the default and prefers installed accelerator providers before CPU
- `provider="cpu"` forces CPU for predictable behavior
- `provider="gpu"` requires an accelerated ONNX Runtime provider and raises a clear error if none are available

The implementation keeps the public API intentionally small (`auto` / `cpu` / `gpu`) and hides ONNX Runtime provider names behind an internal resolver. That matches CollectorVision's simple quickstart-oriented API while still making GPU acceleration possible for users with the right runtime installed.

CollectorVision no longer declares ONNX Runtime as a dependency. Users install exactly one ONNX Runtime backend appropriate for their machine (`onnxruntime`, `onnxruntime-gpu`, DirectML/ROCm variants, etc.), and CollectorVision gives an actionable error the first time neural inference is used without a backend installed. It also warns if both `onnxruntime` and `onnxruntime-gpu` distributions are present because they provide the same Python module and can conflict.

## Rationale

Before this change, `NeuralCornerDetector` and `NeuralEmbedder` both hardcoded `providers=["CPUExecutionProvider"]`, so installing `onnxruntime-gpu` was not enough to use GPU acceleration through CollectorVision. The new default behavior is accelerator-first because that is what most users expect when a capable provider is installed, but it still falls back to CPU if automatic accelerator session creation fails.

Explicit `gpu` does not fall back silently because a user forcing acceleration should get a visible setup error if no accelerator provider is available or the runtime/drivers are not correct. ONNX Runtime can still use CPU as a graph fallback behind an accelerator provider when only part of a model is supported.

I did not add broad ONNX Runtime provider-list plumbing to the main API because it would expose too many magic strings for a library that is intended to stay easy to use. `gpu` is the meaningful user-facing choice across CoreML, CUDA, DirectML, ROCm, and future accelerator providers; we can add advanced provider-list support later if a concrete use case needs it.

Testing on `train4070` exposed two packaging/runtime issues that shaped this final approach:

- Extras cannot cleanly replace a base `onnxruntime` dependency, so GPU installs can accidentally install both `onnxruntime` and `onnxruntime-gpu`, causing the CPU wheel to win and hide CUDA.
- Latest `onnxruntime-gpu` 1.27 requires CUDA 13 runtime libraries on `train4070`, while 1.26 plus CUDA/cuDNN Python runtime packages works on CUDA 12. CollectorVision should not globally pin that decision because newer CUDA users should be able to use newer ONNX Runtime builds.

## Validation

- `uv run --with pytest python -m pytest tests/test_onnx_providers.py tests/test_interfaces.py`
- `uv run --with ruff ruff check collector_vision/onnx_providers.py collector_vision/detectors/neural.py collector_vision/embedders/neural.py tests/test_onnx_providers.py`
- Smoke-tested `NeuralEmbedder` and `NeuralCornerDetector` with `provider="cpu"`, `provider="gpu"` on CoreML, and default `provider="auto"`
- Fresh install with no ONNX Runtime backend imports `collector_vision` successfully and raises actionable backend-install guidance when `NeuralEmbedder()` is constructed
- Warns once per process when both `onnxruntime` and `onnxruntime-gpu` distributions are installed
- On `train4070` Linux/CUDA/RTX 4070, fresh `pip install -e .` followed by manual `pip install "onnxruntime-gpu<1.27" nvidia-cudnn-cu12 nvidia-cuda-runtime-cu12` exposed `CUDAExecutionProvider`, passed targeted tests, and ran real detector + embedder inference with active providers `["CUDAExecutionProvider", "CPUExecutionProvider"]`
