### PR TITLE
Add web scanner asset channel controls

### DIFF
--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -31,6 +31,7 @@ const ROTATION_INVARIANT_KEY = "cv_rotation_invariant_enabled";
 const MIN_MATCHES_DEFAULT = 2;
 const MATCHES_KEY = "cv_min_matches";
 const MIN_CORNER_CONFIDENCE_DEFAULT = 0.02;
+const MAX_CORNER_CONFIDENCE = 0.20;
 const SCAN_BUFFER_SIZE = 5;
 const SCANS_KEY = "cv_scans";
 const PERF_OVERLAY_KEY = "cv_perf_overlay_enabled";
@@ -1516,7 +1517,9 @@ function getScanIntervalMs() {
 
 function getMinCornerConfidence() {
   const stored = Number.parseFloat(localStorage.getItem(CORNER_CONFIDENCE_KEY));
-  return Number.isFinite(stored) ? Math.min(0.1, Math.max(0, stored)) : MIN_CORNER_CONFIDENCE_DEFAULT;
+  return Number.isFinite(stored)
+    ? Math.min(MAX_CORNER_CONFIDENCE, Math.max(0, stored))
+    : MIN_CORNER_CONFIDENCE_DEFAULT;
 }
 
 function getMinMatches() {
@@ -1574,12 +1577,12 @@ function setupCornerConfidenceSlider(scannerWorker = null) {
     label.textContent = value.toFixed(2);
     localStorage.setItem(CORNER_CONFIDENCE_KEY, value);
     scannerWorker?.postMessage({ type: "config", minCornerConfidence: value });
-    updateThresholdMeter("corner-confidence", value, null, 0.1);
+    updateThresholdMeter("corner-confidence", value, null, MAX_CORNER_CONFIDENCE);
   };
 
   slider.value = getMinCornerConfidence();
   label.textContent = getMinCornerConfidence().toFixed(2);
-  updateThresholdMeter("corner-confidence", getMinCornerConfidence(), null, 0.1);
+  updateThresholdMeter("corner-confidence", getMinCornerConfidence(), null, MAX_CORNER_CONFIDENCE);
   slider.addEventListener("input", update);
 }
 
@@ -1935,7 +1938,7 @@ function createScannerLoop(
     diag.set("diag-detector-input", data.detectorInput ?? "—");
     diag.set("diag-raw-corners", data.rawCorners ?? "—");
     diag.set("diag-sharpness", `${data.sharpness?.toFixed(3) ?? "—"} (card ${data.cardPresent ? "yes" : "no"})`);
-    updateThresholdMeter("corner-confidence", getMinCornerConfidence(), data.sharpness, 0.1);
+    updateThresholdMeter("corner-confidence", getMinCornerConfidence(), data.sharpness, MAX_CORNER_CONFIDENCE);
     updateThresholdMeter("match-score", getMinMatchScore(), data.score, 1);
 
     if (data.timing) {
@@ -2050,6 +2053,35 @@ function resolveAssetChannel() {
   return Object.hasOwn(ASSET_CHANNELS, requested) ? requested : "stable";
 }
 
+function channelUrl(path, channel) {
+  const url = new URL(path, location.href);
+  if (channel === "stable") {
+    url.searchParams.delete("channel");
+  } else {
+    url.searchParams.set("channel", channel);
+  }
+  return url.href;
+}
+
+function setupAssetChannelUi(channel) {
+  const label = channel === "testing" ? "testing assets" : "stable assets";
+  setText("asset-channel-pill", label);
+  setText("asset-channel-current", channel);
+
+  const switchLink = document.getElementById("asset-channel-switch");
+  if (switchLink) {
+    const nextChannel = channel === "testing" ? "stable" : "testing";
+    switchLink.href = channelUrl(location.href, nextChannel);
+    switchLink.textContent = `Switch to ${nextChannel} assets`;
+  }
+
+  document.querySelectorAll("[data-preserve-channel]").forEach((link) => {
+    const rawHref = link.getAttribute("href");
+    if (!rawHref) return;
+    link.href = channelUrl(rawHref, channel);
+  });
+}
+
 function resolveCatalogMode() {
   const requested = new URLSearchParams(location.search).get("catalog") ?? "v2";
   if (requested !== "v1" && requested !== "v2") {
@@ -2156,6 +2188,7 @@ async function boot() {
   // Load the manifest on the main thread first — it drives both the loading
   // screen text and the worker init message.
   const channel = resolveAssetChannel();
+  setupAssetChannelUi(channel);
   const catalogMode = resolveCatalogMode();
   const { assetBasePath, manifest } = await loadManifest(channel);
   const catalogLimit = getCatalogLimitFromQuery();

--- a/examples/web_scanner/applet_example.css
+++ b/examples/web_scanner/applet_example.css
@@ -118,6 +118,26 @@ tr:last-child td { border-bottom: 0; }
   text-transform: uppercase;
 }
 
+.channel-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.85rem;
+}
+
+.channel-nav span,
+.channel-nav a {
+  border: 1px solid rgba(36, 33, 31, 0.14);
+  border-radius: 999px;
+  padding: 0.45rem 0.7rem;
+  background: rgba(255, 255, 255, 0.58);
+  color: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
 .layout {
   display: grid;
   align-items: start;

--- a/examples/web_scanner/applet_example.html
+++ b/examples/web_scanner/applet_example.html
@@ -50,6 +50,12 @@
         <p class="eyebrow">Candidate API</p>
         <h1>Scanner Playground</h1>
         <p>Try preset card handlers, edit the JavaScript, and see how the applet can fit into your own page. This playground keeps everything local in your browser: apply a handler, then scan a card. Need to disable cross-origin isolation for debugging? Open with <code>?coi=0</code>.</p>
+        <nav class="channel-nav" aria-label="Asset channel">
+          <span>Assets: <strong id="asset-channel-current">stable</strong></span>
+          <a id="asset-channel-switch" href="./applet_example.html">Switch channel</a>
+          <a data-preserve-channel href="./">Main scanner</a>
+          <a data-preserve-channel href="./screen_capture_monitor.html">Screen capture monitor</a>
+        </nav>
       </header>
 
       <section class="layout">

--- a/examples/web_scanner/applet_example.js
+++ b/examples/web_scanner/applet_example.js
@@ -28,8 +28,35 @@ function resolveAssetChannel() {
   return Object.hasOwn(ASSET_CHANNELS, requested) ? requested : "stable";
 }
 
+function channelUrl(path, channel) {
+  const url = new URL(path, location.href);
+  if (channel === "stable") {
+    url.searchParams.delete("channel");
+  } else {
+    url.searchParams.set("channel", channel);
+  }
+  return url.href;
+}
+
+function setupAssetChannelUi(channel) {
+  const current = document.getElementById("asset-channel-current");
+  const switchLink = document.getElementById("asset-channel-switch");
+  if (current) current.textContent = channel;
+  if (switchLink) {
+    const nextChannel = channel === "testing" ? "stable" : "testing";
+    switchLink.href = channelUrl(location.href, nextChannel);
+    switchLink.textContent = `Switch to ${nextChannel}`;
+  }
+  document.querySelectorAll("[data-preserve-channel]").forEach((link) => {
+    const rawHref = link.getAttribute("href");
+    if (!rawHref) return;
+    link.href = channelUrl(rawHref, channel);
+  });
+}
+
 const assetChannel = resolveAssetChannel();
 const assetBasePath = ASSET_CHANNELS[assetChannel];
+setupAssetChannelUi(assetChannel);
 
 const PRESETS = [
   {

--- a/examples/web_scanner/index.html
+++ b/examples/web_scanner/index.html
@@ -107,7 +107,10 @@
     <div class="app-shell">
       <main class="page">
         <header class="app-bar">
-          <h1 class="app-bar__title">CollectorVision</h1>
+          <div>
+            <h1 class="app-bar__title">CollectorVision</h1>
+            <p class="channel-pill" id="asset-channel-pill">stable assets</p>
+          </div>
           <div class="app-bar__actions">
             <button class="icon-button icon-button--debug" id="debug-toggle" type="button" aria-label="Show debug panel" aria-expanded="false">
               Debug
@@ -177,6 +180,21 @@
             </a>
           </section>
 
+          <section class="panel panel--nested">
+            <header class="panel-header">
+              <div>
+                <p class="section-kicker">Assets</p>
+                <h2>Asset Channel</h2>
+              </div>
+            </header>
+            <p class="capture-hint">
+              Current channel: <strong id="asset-channel-current">stable</strong>.
+              Use testing to try the latest detector/catalog bundle without changing the scanner code.
+            </p>
+            <a class="action-button action-button--block" id="asset-channel-switch" href="./">Switch channel</a>
+            <a class="action-button action-button--block" data-preserve-channel href="./applet_example.html">▶ Open Scanner Playground</a>
+          </section>
+
           <section class="panel panel--nested" id="webgpu-toggle-section" hidden>
             <header class="panel-header">
               <div>
@@ -231,7 +249,7 @@
               </div>
             </header>
             <p class="capture-hint">Watch a shared tab, window, or screen, crop to a region of interest, and emit card events for overlays or CSV/JSONL export.</p>
-            <a class="action-button action-button--block" href="./screen_capture_monitor.html">▶ Open Screen Capture Monitor</a>
+            <a class="action-button action-button--block" data-preserve-channel href="./screen_capture_monitor.html">▶ Open Screen Capture Monitor</a>
           </section>
 
           <section class="panel panel--nested">
@@ -242,15 +260,15 @@
               </div>
             </header>
             <p class="capture-hint">Runs the model benchmark and downloads a GitHub-ready Markdown report. WASM is recommended; WebGPU is experimental.</p>
-            <a class="action-button action-button--block" href="./model_benchmark.html?backend=wasm&amp;download=md">▶ Run WASM Benchmark</a>
-            <a class="action-button action-button--block" href="./model_benchmark.html?backend=webgpu&amp;download=md">▶ Run WebGPU Benchmark</a>
+            <a class="action-button action-button--block" data-preserve-channel href="./model_benchmark.html?backend=wasm&amp;download=md">▶ Run WASM Benchmark</a>
+            <a class="action-button action-button--block" data-preserve-channel href="./model_benchmark.html?backend=webgpu&amp;download=md">▶ Run WebGPU Benchmark</a>
           </section>
 
           <section class="panel panel--nested">
             <header class="panel-header">
               <div>
                 <p class="section-kicker">Recognition</p>
-                <h2>Match Threshold</h2>
+                <h2>Match &amp; Sharpness Thresholds</h2>
               </div>
             </header>
             <label class="slider-row" for="match-score-slider">
@@ -267,12 +285,12 @@
             <p class="threshold-meter__value" id="match-score-signal-value">Current —</p>
             <p class="capture-hint">Lower values accept weaker matches (more false positives); higher values require a stronger match. Default 0.50.</p>
             <label class="slider-row" for="corner-confidence-slider">
-              <span class="slider-row__label">Minimum corner sharpness</span>
+              <span class="slider-row__label">Minimum corner sharpness threshold</span>
               <span class="slider-row__value" id="corner-confidence-value">0.02</span>
             </label>
             <input type="range" id="corner-confidence-slider"
               class="threshold-slider"
-              min="0" max="0.10" step="0.01" value="0.02" />
+              min="0" max="0.20" step="0.01" value="0.02" />
             <div class="threshold-meter" aria-live="polite">
               <span class="threshold-meter__fill" id="corner-confidence-signal-fill"></span>
               <span class="threshold-meter__threshold" id="corner-confidence-signal-threshold"></span>

--- a/examples/web_scanner/model_benchmark.html
+++ b/examples/web_scanner/model_benchmark.html
@@ -129,8 +129,19 @@
         }
       }
 
+      const ASSET_CHANNELS = {
+        stable: "./assets",
+        testing: "./testing/assets",
+      };
+
+      function resolveAssetChannel() {
+        const requested = new URLSearchParams(location.search).get("channel") ?? "stable";
+        return Object.hasOwn(ASSET_CHANNELS, requested) ? requested : "stable";
+      }
+
       async function loadModels() {
-        const response = await fetch("./assets/manifest.json", { cache: "no-store" });
+        const assetBasePath = ASSET_CHANNELS[resolveAssetChannel()];
+        const response = await fetch(`${assetBasePath}/manifest.json`, { cache: "no-store" });
         if (!response.ok) {
           throw new Error(`Failed to load asset manifest: ${response.status}`);
         }
@@ -146,13 +157,13 @@
           {
             name: detectorFamily,
             version: versions[detectorKey] ?? "unknown",
-            path: `./assets/${manifest.models[detectorKey]}`,
+            path: `${assetBasePath}/${manifest.models[detectorKey]}`,
             shape: [1, 3, detectorSize, detectorSize],
           },
           {
             name: "milo",
             version: versions.milo ?? "unknown",
-            path: `./assets/${manifest.models.milo}`,
+            path: `${assetBasePath}/${manifest.models.milo}`,
             shape: [1, 3, 448, 448],
           },
         ];

--- a/examples/web_scanner/scanner.worker.mjs
+++ b/examples/web_scanner/scanner.worker.mjs
@@ -425,8 +425,8 @@ async function fetchWithProgress(url, responseType, expectedTotal, onProgress) {
   return await blob.arrayBuffer();
 }
 
-async function fetchJsonCached(url, version, expectedTotal, onProgress) {
-  const key = `${version}:${url}:json`;
+async function fetchJsonCached(url, version, expectedTotal, onProgress, cacheIdentity = url) {
+  const key = `${version}:${cacheIdentity}:json`;
   const cached = await readCachedAsset(key);
   if (cached) {
     onProgress?.(1, 1, 1, true);
@@ -439,8 +439,8 @@ async function fetchJsonCached(url, version, expectedTotal, onProgress) {
   return json;
 }
 
-async function fetchBufferCached(url, version, expectedTotal, onProgress) {
-  const key = `${version}:${url}:buffer`;
+async function fetchBufferCached(url, version, expectedTotal, onProgress, cacheIdentity = url) {
+  const key = `${version}:${cacheIdentity}:buffer`;
   const cached = await readCachedAsset(key);
   if (cached) {
     onProgress?.(1, cached.byteLength ?? 1, cached.byteLength ?? 1, true);
@@ -613,12 +613,14 @@ class WorkerRuntime {
       detectorVersion,
       modelSizes[this.detectorConfig.modelKey],
       (ratio, loaded, total, cached) => onStage?.("detector", ratio, loaded, total, cached),
+      `model:${this.detectorConfig.modelKey}`,
     );
     const embedderBuffer = await fetchBufferCached(
       `${this.assetBasePath}/${this.manifest.models.milo}`,
       embedderVersion,
       modelSizes.milo,
       (ratio, loaded, total, cached) => onStage?.("embedder", ratio, loaded, total, cached),
+      "model:milo",
     );
 
     // Use as many threads as the device has cores, capped at 4.
@@ -659,42 +661,71 @@ class WorkerRuntime {
       { key: "card_ids", size: catalogAssetSizes.card_ids },
       ...(secondarySource ? [{ key: "oracle_ids", size: catalogAssetSizes.oracle_ids }] : []),
     ];
-    const catalogTotal = catalogParts.reduce(
+    const knownCatalogTotal = catalogParts.every(
+      (part) => Number.isSafeInteger(part.size) && part.size > 0,
+    );
+    const catalogTotal = knownCatalogTotal ? catalogParts.reduce(
       (total, part) => total + (Number.isSafeInteger(part.size) && part.size > 0 ? part.size : 0),
       0,
-    );
-    const reportCatalogProgress = (partIndex, loaded, total, cached) => {
-      const completed = catalogParts.slice(0, partIndex).reduce(
-        (sum, part) => sum + (Number.isSafeInteger(part.size) && part.size > 0 ? part.size : 0),
-        0,
-      );
+    ) : 0;
+    const observedPartSizes = new Map();
+    const partSize = (partIndex) => {
+      const declared = catalogParts[partIndex]?.size;
+      if (Number.isSafeInteger(declared) && declared > 0) return declared;
+      return observedPartSizes.get(partIndex) ?? 0;
+    };
+    const completedCatalogBytes = (partIndex) => {
+      let completed = 0;
+      for (let i = 0; i < partIndex; i += 1) {
+        completed += partSize(i);
+      }
+      return completed;
+    };
+    const reportCatalogProgress = (partIndex, ratio, loaded, total, cached) => {
+      const safeLoaded = Number.isFinite(loaded) && loaded > 0 ? loaded : 0;
+      const safeTotal = Number.isFinite(total) && total > 0 ? total : 0;
+      const completed = completedCatalogBytes(partIndex);
+      const observedTotal = Math.max(partSize(partIndex), safeTotal, safeLoaded);
+      if ((cached || ratio >= 1) && observedTotal > 0) {
+        observedPartSizes.set(partIndex, observedTotal);
+      }
       const expected = catalogParts[partIndex].size;
       if (catalogTotal > 0 && Number.isSafeInteger(expected) && expected > 0) {
-        const current = cached ? expected : Math.min(loaded, expected);
+        const current = cached ? expected : Math.min(safeLoaded, expected);
         const aggregate = completed + current;
         onStage?.("catalog", aggregate / catalogTotal, aggregate, catalogTotal, false);
         return;
       }
-      onStage?.("catalog", total > 0 ? loaded / total : 0, loaded, total, cached);
+      const partRatio = cached ? 1 : Math.max(0, Math.min(1, Number.isFinite(ratio) ? ratio : 0));
+      onStage?.(
+        "catalog",
+        (partIndex + partRatio) / catalogParts.length,
+        completed + safeLoaded,
+        0,
+        cached,
+      );
     };
     const embeddingBuffer = await fetchBufferCached(
       `${this.assetBasePath}/${this.manifest.catalog.embeddings}`,
       version,
       catalogAssetSizes.embeddings,
-      (ratio, loaded, total, cached) => reportCatalogProgress(0, loaded, total, cached),
+      (ratio, loaded, total, cached) => reportCatalogProgress(0, ratio, loaded, total, cached),
+      `catalog:${this.manifest.catalog.embeddings}`,
     );
     const ids = await fetchJsonCached(
       `${this.assetBasePath}/${this.manifest.catalog.card_ids}`,
       version,
       catalogAssetSizes.card_ids,
-      (ratio, loaded, total, cached) => reportCatalogProgress(1, loaded, total, cached),
+      (ratio, loaded, total, cached) => reportCatalogProgress(1, ratio, loaded, total, cached),
+      `catalog:${this.manifest.catalog.card_ids}`,
     );
     const secondaryIds = secondarySource
       ? await fetchJsonCached(
         `${this.assetBasePath}/${secondarySource.assetPath}`,
         version,
         catalogAssetSizes.oracle_ids,
-        (ratio, loaded, total, cached) => reportCatalogProgress(2, loaded, total, cached),
+        (ratio, loaded, total, cached) => reportCatalogProgress(2, ratio, loaded, total, cached),
+        `catalog:${secondarySource.assetPath}`,
       )
       : null;
     // Keep the catalog in its packed float16 form.  Expanding the full MTG

--- a/examples/web_scanner/screen_capture_monitor.css
+++ b/examples/web_scanner/screen_capture_monitor.css
@@ -39,6 +39,7 @@ button {
 
 button.secondary,
 .hero-links a,
+.channel-chip,
 .button-link {
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.08);
@@ -119,7 +120,8 @@ code {
   gap: 0.5rem;
 }
 
-.hero-links a {
+.hero-links a,
+.channel-chip {
   min-height: 2.55rem;
   display: inline-flex;
   align-items: center;

--- a/examples/web_scanner/screen_capture_monitor.html
+++ b/examples/web_scanner/screen_capture_monitor.html
@@ -60,8 +60,10 @@
             </dl>
           </aside>
           <nav class="hero-links" aria-label="Related pages">
-            <a href="./">Scanner</a>
-            <a href="./applet_example.html">Playground</a>
+            <span class="channel-chip">Assets: <strong id="asset-channel-current">stable</strong></span>
+            <a id="asset-channel-switch" href="./screen_capture_monitor.html">Switch channel</a>
+            <a data-preserve-channel href="./">Scanner</a>
+            <a data-preserve-channel href="./applet_example.html">Playground</a>
             <a href="./screen_capture_overlay.html" target="_blank" rel="noopener noreferrer">Overlay</a>
           </nav>
         </div>

--- a/examples/web_scanner/screen_capture_monitor.js
+++ b/examples/web_scanner/screen_capture_monitor.js
@@ -104,9 +104,36 @@ function resolveAssetChannel() {
   return Object.hasOwn(ASSET_CHANNELS, requested) ? requested : "stable";
 }
 
+function channelUrl(path, channel) {
+  const url = new URL(path, location.href);
+  if (channel === "stable") {
+    url.searchParams.delete("channel");
+  } else {
+    url.searchParams.set("channel", channel);
+  }
+  return url.href;
+}
+
+function setupAssetChannelUi(channel) {
+  const current = document.getElementById("asset-channel-current");
+  const switchLink = document.getElementById("asset-channel-switch");
+  if (current) current.textContent = channel;
+  if (switchLink) {
+    const nextChannel = channel === "testing" ? "stable" : "testing";
+    switchLink.href = channelUrl(location.href, nextChannel);
+    switchLink.textContent = `Switch to ${nextChannel}`;
+  }
+  document.querySelectorAll("[data-preserve-channel]").forEach((link) => {
+    const rawHref = link.getAttribute("href");
+    if (!rawHref) return;
+    link.href = channelUrl(rawHref, channel);
+  });
+}
+
 init();
 
 async function init() {
+  setupAssetChannelUi(resolveAssetChannel());
   applySettingsToInputs();
   applyRoiToBox();
   bindUi();

--- a/examples/web_scanner/style.css
+++ b/examples/web_scanner/style.css
@@ -169,6 +169,15 @@ body[data-loading="true"] .loading-screen {
   font-weight: 600;
 }
 
+.channel-pill {
+  margin: 0.25rem 0 0;
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 .app-bar__actions {
   display: flex;
   gap: 0.55rem;


### PR DESCRIPTION
Adds visible stable/testing asset-channel switching to the main web scanner, scanner playground, screen capture monitor, and benchmark. Preserves the selected channel when navigating between pages and makes the main scanner corner sharpness threshold control explicit.

Validation: `npm --prefix tests/js test`.