### PR TITLE
Add playground channel controls and meter markup

### DIFF
--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -31,6 +31,7 @@ const ROTATION_INVARIANT_KEY = "cv_rotation_invariant_enabled";
 const MIN_MATCHES_DEFAULT = 2;
 const MATCHES_KEY = "cv_min_matches";
 const MIN_CORNER_CONFIDENCE_DEFAULT = 0.02;
+const MAX_CORNER_CONFIDENCE = 0.20;
 const SCAN_BUFFER_SIZE = 5;
 const SCANS_KEY = "cv_scans";
 const PERF_OVERLAY_KEY = "cv_perf_overlay_enabled";
@@ -1516,7 +1517,9 @@ function getScanIntervalMs() {
 
 function getMinCornerConfidence() {
   const stored = Number.parseFloat(localStorage.getItem(CORNER_CONFIDENCE_KEY));
-  return Number.isFinite(stored) ? Math.min(0.1, Math.max(0, stored)) : MIN_CORNER_CONFIDENCE_DEFAULT;
+  return Number.isFinite(stored)
+    ? Math.min(MAX_CORNER_CONFIDENCE, Math.max(0, stored))
+    : MIN_CORNER_CONFIDENCE_DEFAULT;
 }
 
 function getMinMatches() {
@@ -1535,13 +1538,13 @@ function setupMatchScoreSlider() {
 
   slider.value = getMinMatchScore();
   label.textContent = getMinMatchScore().toFixed(2);
-  updateThresholdMeter("match-score", getMinMatchScore(), null, 1);
+  updateThresholdMeter("match-score", getMinMatchScore(), null, 1, { preserveCurrent: true });
 
   slider.addEventListener("input", () => {
     const value = Number.parseFloat(slider.value);
     label.textContent = value.toFixed(2);
     localStorage.setItem(MATCH_SCORE_KEY, value);
-    updateThresholdMeter("match-score", value, null, 1);
+    updateThresholdMeter("match-score", value, null, 1, { preserveCurrent: true });
   });
 }
 
@@ -1574,16 +1577,17 @@ function setupCornerConfidenceSlider(scannerWorker = null) {
     label.textContent = value.toFixed(2);
     localStorage.setItem(CORNER_CONFIDENCE_KEY, value);
     scannerWorker?.postMessage({ type: "config", minCornerConfidence: value });
-    updateThresholdMeter("corner-confidence", value, null, 0.1);
+    updateThresholdMeter("corner-confidence", value, null, MAX_CORNER_CONFIDENCE, { preserveCurrent: true });
   };
 
+  slider.max = String(MAX_CORNER_CONFIDENCE);
   slider.value = getMinCornerConfidence();
   label.textContent = getMinCornerConfidence().toFixed(2);
-  updateThresholdMeter("corner-confidence", getMinCornerConfidence(), null, 0.1);
+  updateThresholdMeter("corner-confidence", getMinCornerConfidence(), null, MAX_CORNER_CONFIDENCE, { preserveCurrent: true });
   slider.addEventListener("input", update);
 }
 
-function updateThresholdMeter(name, threshold, current, maximum) {
+function updateThresholdMeter(name, threshold, current, maximum, options = {}) {
   const fill = document.getElementById(`${name}-signal-fill`);
   const marker = document.getElementById(`${name}-signal-threshold`);
   const value = document.getElementById(`${name}-signal-value`);
@@ -1591,8 +1595,10 @@ function updateThresholdMeter(name, threshold, current, maximum) {
 
   marker.style.left = `${(Math.min(1, Math.max(0, threshold / maximum)) * 100).toFixed(1)}%`;
   if (!Number.isFinite(current)) {
-    fill.style.width = "0%";
-    value.textContent = "Current —";
+    if (!options.preserveCurrent) {
+      fill.style.width = "0%";
+      value.textContent = "Current —";
+    }
     return;
   }
   fill.style.width = `${(Math.min(1, Math.max(0, current / maximum)) * 100).toFixed(1)}%`;
@@ -1935,7 +1941,7 @@ function createScannerLoop(
     diag.set("diag-detector-input", data.detectorInput ?? "—");
     diag.set("diag-raw-corners", data.rawCorners ?? "—");
     diag.set("diag-sharpness", `${data.sharpness?.toFixed(3) ?? "—"} (card ${data.cardPresent ? "yes" : "no"})`);
-    updateThresholdMeter("corner-confidence", getMinCornerConfidence(), data.sharpness, 0.1);
+    updateThresholdMeter("corner-confidence", getMinCornerConfidence(), data.sharpness, MAX_CORNER_CONFIDENCE);
     updateThresholdMeter("match-score", getMinMatchScore(), data.score, 1);
 
     if (data.timing) {

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -1680,16 +1680,18 @@ class PerformanceOverlay {
     const threads = this.captureState?.numThreads ?? "—";
     const mode = this.captureState?.inferenceMode ?? "—";
     const resultGap = data?.resultGapMs ? formatMs(data.resultGapMs) : "—";
-    const resultFps = data?.resultGapMs ? `${(1000 / data.resultGapMs).toFixed(1)} FPS` : "— FPS";
+    const observedFps = data?.resultGapMs ? `${(1000 / data.resultGapMs).toFixed(1)} fps` : "— fps";
+    const calculatedFps = timing.totalMs ? `${(1000 / timing.totalMs).toFixed(1)} fps` : "— fps";
+    const threadLabel = String(mode).startsWith("WASM") ? "wasm_threads" : "threads";
     const score = Number.isFinite(data?.score) ? data.score.toFixed(3) : "—";
     const card = data?.cardPresent ? (data.cornersValid ? "card" : "bad-quad") : "no-card";
     const orientation = data?.orientation ? `  ${data.orientation}` : "";
     this.el.textContent = [
-      `minimum interval ${getScanIntervalMs()}ms  result ${resultGap}  ${resultFps}`,
+      `minimum interval ${getScanIntervalMs()}ms  result ${resultGap}  observed ${observedFps}  calculated ${calculatedFps}`,
       `total ${formatMs(timing.totalMs)}  det ${formatMs(timing.detectMs)} (run ${formatMs(timing.detectorRunMs)})`,
       `dew ${formatMs(timing.dewarpMs)} (warp ${formatMs(timing.dewarpWarpMs)})  emb ${formatMs(timing.embedMs)} (run ${formatMs(timing.embedRunMs)})`,
       `prep det ${formatMs(timing.detectorInputMs)}  prep emb ${formatMs(timing.embedInputMs)}  lookup ${formatMs(timing.searchMs)}`,
-      `${mode}  threads ${threads}  ${card}  score ${score}${orientation}`,
+      `${mode}  ${threadLabel} ${threads}  ${card}  score ${score}${orientation}`,
       `${this.memoryLine()}  catalog ${formatMiB(this.catalogBytes)}`,
     ].join("\n");
   }

--- a/examples/web_scanner/applet_example.html
+++ b/examples/web_scanner/applet_example.html
@@ -83,8 +83,8 @@
               </div>
               <label class="scan-settings-field">Consecutive scans <input id="scan-consecutive" type="number" min="1" max="6" step="1" /></label>
               <label class="scan-settings-slider">
-                Scan interval <span id="scan-interval-label">900ms</span>
-                <input id="scan-interval" type="range" min="0" max="1200" step="25" />
+                Scan interval <span id="scan-interval-label">50ms</span>
+                <input id="scan-interval" type="range" min="0" max="1000" step="25" />
               </label>
               <label class="scan-settings-toggle"><input id="scan-webgpu" type="checkbox" /> <span>Enable WebGPU (experimental)</span></label>
               <label class="scan-settings-toggle"><input id="scan-fps-overlay" type="checkbox" /> <span>Show FPS debug overlay</span></label>

--- a/examples/web_scanner/applet_example.html
+++ b/examples/web_scanner/applet_example.html
@@ -50,6 +50,12 @@
         <p class="eyebrow">Candidate API</p>
         <h1>Scanner Playground</h1>
         <p>Try preset card handlers, edit the JavaScript, and see how the applet can fit into your own page. This playground keeps everything local in your browser: apply a handler, then scan a card. Need to disable cross-origin isolation for debugging? Open with <code>?coi=0</code>.</p>
+        <nav class="channel-nav" aria-label="Asset channel">
+          <span>Assets: <strong id="asset-channel-current">stable</strong></span>
+          <a id="asset-channel-switch" href="./applet_example.html">Switch channel</a>
+          <a data-preserve-channel href="./">Main scanner</a>
+          <a data-preserve-channel href="./screen_capture_monitor.html">Screen capture monitor</a>
+        </nav>
       </header>
 
       <section class="layout">
@@ -130,6 +136,37 @@
       </section>
     </main>
 
+    <script>
+      (function () {
+        var channels = { stable: "./assets", testing: "./testing/assets" };
+        var params = new URLSearchParams(location.search);
+        var channel = Object.prototype.hasOwnProperty.call(channels, params.get("channel"))
+          ? params.get("channel")
+          : "stable";
+
+        function channelUrl(path, nextChannel) {
+          var url = new URL(path, location.href);
+          if (nextChannel === "stable") {
+            url.searchParams.delete("channel");
+          } else {
+            url.searchParams.set("channel", nextChannel);
+          }
+          return url.href;
+        }
+
+        var current = document.getElementById("asset-channel-current");
+        var switchLink = document.getElementById("asset-channel-switch");
+        if (current) current.textContent = channel;
+        if (switchLink) {
+          var next = channel === "testing" ? "stable" : "testing";
+          switchLink.href = channelUrl(location.href, next);
+          switchLink.textContent = "Switch to " + next;
+        }
+        document.querySelectorAll("[data-preserve-channel]").forEach(function (link) {
+          link.href = channelUrl(link.getAttribute("href"), channel);
+        });
+      })();
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js" data-manual></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-clike.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-javascript.min.js"></script>

--- a/examples/web_scanner/applet_example.js
+++ b/examples/web_scanner/applet_example.js
@@ -183,7 +183,7 @@ function populateScanSettings() {
   cornerThresholdInput.value = cornerThreshold.toFixed(2);
   updateCornerThresholdUi(cornerThreshold);
   thresholdInput.value = settings.matchThreshold.toFixed(2);
-  updateMatchSignal(null);
+  updateMatchThresholdUi(settings.matchThreshold);
   consecutiveInput.value = String(settings.consecutiveMatches);
   intervalInput.value = String(Math.max(0, Math.round(Number(settings.scanIntervalMs) || 0)));
   intervalLabel.textContent = Number(intervalInput.value) <= 0 ? "Max speed" : `${intervalInput.value}ms`;
@@ -199,6 +199,11 @@ function updateCornerThresholdUi(value) {
   cornerSignalThreshold.style.left = `${(ratio * 100).toFixed(1)}%`;
 }
 
+function updateMatchThresholdUi(value) {
+  const threshold = clamp(Number(value), 0, 1);
+  matchSignalThreshold.style.left = `${(threshold * 100).toFixed(1)}%`;
+}
+
 function updateCornerSignal(confidence) {
   const raw = Math.max(0, Number(confidence) || 0);
   const current = clamp(raw, 0, MAX_GUI_CORNER_CONFIDENCE);
@@ -210,8 +215,7 @@ function updateCornerSignal(confidence) {
 }
 
 function updateMatchSignal(score) {
-  const threshold = clamp(Number(thresholdInput.value), 0, 1);
-  matchSignalThreshold.style.left = `${(threshold * 100).toFixed(1)}%`;
+  updateMatchThresholdUi(thresholdInput.value);
   if (!Number.isFinite(score)) {
     matchSignalFill.style.width = "0%";
     matchSignalValue.textContent = "Current —";
@@ -246,7 +250,7 @@ async function applyScanSettings({ announce = true } = {}) {
   cornerThresholdInput.value = settings.minCornerConfidence.toFixed(2);
   updateCornerThresholdUi(settings.minCornerConfidence);
   thresholdInput.value = settings.matchThreshold.toFixed(2);
-  updateMatchSignal(null);
+  updateMatchThresholdUi(settings.matchThreshold);
   consecutiveInput.value = String(settings.consecutiveMatches);
   intervalInput.value = String(settings.scanIntervalMs);
   intervalLabel.textContent = settings.scanIntervalMs <= 0 ? "Max speed" : `${settings.scanIntervalMs}ms`;
@@ -283,6 +287,10 @@ intervalInput.addEventListener("input", () => {
 
 cornerThresholdInput.addEventListener("input", () => {
   updateCornerThresholdUi(cornerThresholdInput.value);
+});
+
+thresholdInput.addEventListener("input", () => {
+  updateMatchThresholdUi(thresholdInput.value);
 });
 
 function highlightReadonlySignature() {

--- a/examples/web_scanner/applet_example.js
+++ b/examples/web_scanner/applet_example.js
@@ -12,11 +12,13 @@ const ASSET_CHANNELS = {
 };
 const LOG_LIMIT = 12;
 const SCRYFALL_CARD_URL = "https://api.scryfall.com/cards/${card.cardId}";
+const SCAN_INTERVAL_DEFAULT_MS = 50;
+const SCAN_INTERVAL_MAX_MS = 1000;
 const DEFAULT_SCAN_SETTINGS = {
   minCornerConfidence: 0.02,
   matchThreshold: 0.50,
   consecutiveMatches: 2,
-  scanIntervalMs: 900,
+  scanIntervalMs: SCAN_INTERVAL_DEFAULT_MS,
   enableWebGpu: false,
   showFpsOverlay: true,
   groupBySecondaryId: true,
@@ -185,7 +187,9 @@ function populateScanSettings() {
   thresholdInput.value = settings.matchThreshold.toFixed(2);
   updateMatchThresholdUi(settings.matchThreshold);
   consecutiveInput.value = String(settings.consecutiveMatches);
-  intervalInput.value = String(Math.max(0, Math.round(Number(settings.scanIntervalMs) || 0)));
+  intervalInput.value = String(
+    Math.min(SCAN_INTERVAL_MAX_MS, Math.max(0, Math.round(Number(settings.scanIntervalMs) || 0))),
+  );
   intervalLabel.textContent = Number(intervalInput.value) <= 0 ? "Max speed" : `${intervalInput.value}ms`;
   webGpuInput.checked = settings.enableWebGpu === true;
   fpsOverlayInput.checked = settings.showFpsOverlay !== false;
@@ -230,7 +234,10 @@ function scanSettingsFromInputs() {
   const minCornerConfidence = clamp(Number(cornerThresholdInput.value), 0, MAX_GUI_CORNER_CONFIDENCE);
   const matchThreshold = clamp(Number(thresholdInput.value), 0, 1);
   const consecutiveMatches = Math.max(1, Math.round(Number(consecutiveInput.value) || 1));
-  const scanIntervalMs = Math.max(0, Math.round(Number(intervalInput.value) || 0));
+  const scanIntervalMs = Math.min(
+    SCAN_INTERVAL_MAX_MS,
+    Math.max(0, Math.round(Number(intervalInput.value) || 0)),
+  );
   const enableWebGpu = webGpuInput.checked === true;
   const showFpsOverlay = fpsOverlayInput.checked === true;
   const groupBySecondaryId = groupSecondaryInput.checked === true;

--- a/examples/web_scanner/lib/collectorvision-scanner-applet.mjs
+++ b/examples/web_scanner/lib/collectorvision-scanner-applet.mjs
@@ -10,7 +10,7 @@ const DEFAULT_CONFIG = {
   workerUrl: versionedUrl("../scanner.worker.mjs"),
   enableWebGpu: false,
   autoStart: true,
-  scanIntervalMs: 900,
+  scanIntervalMs: 50,
   minCornerConfidence: 0.02,
   matchThreshold: 0.5,
   consecutiveMatches: 2,

--- a/examples/web_scanner/screen_capture_monitor.html
+++ b/examples/web_scanner/screen_capture_monitor.html
@@ -146,8 +146,8 @@
               <input id="consecutive-matches" type="number" min="1" max="8" step="1" value="2" />
             </label>
             <label>
-              <span>Minimum frame interval <output id="scan-interval-value">500 ms</output></span>
-              <input id="scan-interval" type="range" min="0" max="2500" step="50" value="500" />
+              <span>Minimum frame interval <output id="scan-interval-value">50 ms</output></span>
+              <input id="scan-interval" type="range" min="0" max="1000" step="50" value="50" />
             </label>
             <label>
               Corner threshold

--- a/examples/web_scanner/screen_capture_monitor.js
+++ b/examples/web_scanner/screen_capture_monitor.js
@@ -7,6 +7,8 @@ const ASSET_CHANNELS = {
 const ROI_KEY = "collectorvision_screen_monitor_roi";
 const SETTINGS_KEY = "collectorvision_screen_monitor_settings";
 const MAX_EVENTS = 250;
+const SCAN_INTERVAL_DEFAULT_MS = 50;
+const SCAN_INTERVAL_MAX_MS = 1000;
 const KNOWN_MODEL_VERSIONS = {
   cornelius: {
     "sha256:a90ee87a45781e09e9fc88508162dac87b0492162dff79a2627c52ae773e6a79": "1.205",
@@ -21,7 +23,7 @@ const KNOWN_MODEL_VERSIONS = {
 const DEFAULT_SETTINGS = {
   matchThreshold: 0.50,
   consecutiveMatches: 2,
-  scanIntervalMs: 500,
+  scanIntervalMs: SCAN_INTERVAL_DEFAULT_MS,
   minCornerConfidence: 0.02,
   groupBySecondaryId: true,
   showRejectedDetections: true,
@@ -736,7 +738,7 @@ function readSettings() {
 function applySettingsToInputs() {
   els.matchThreshold.value = settings.matchThreshold.toFixed(2);
   els.consecutiveMatches.value = String(settings.consecutiveMatches);
-  els.scanInterval.value = String(settings.scanIntervalMs);
+  els.scanInterval.value = String(Math.min(SCAN_INTERVAL_MAX_MS, Math.max(0, settings.scanIntervalMs)));
   updateScanIntervalLabel();
   els.cornerThreshold.value = settings.minCornerConfidence.toFixed(2);
   els.groupSecondary.checked = settings.groupBySecondaryId === true;
@@ -753,7 +755,10 @@ function updateSettingsFromInputs() {
   settings = {
     matchThreshold: clamp(Number(els.matchThreshold.value), 0, 1),
     consecutiveMatches: Math.max(1, Math.round(Number(els.consecutiveMatches.value) || 1)),
-    scanIntervalMs: Math.max(0, Math.round(Number(els.scanInterval.value) || 0)),
+    scanIntervalMs: Math.min(
+      SCAN_INTERVAL_MAX_MS,
+      Math.max(0, Math.round(Number(els.scanInterval.value) || 0)),
+    ),
     minCornerConfidence: clamp(Number(els.cornerThreshold.value), 0, 0.2),
     groupBySecondaryId: els.groupSecondary.checked === true,
     showRejectedDetections: els.showRejectedDetections.checked === true,

--- a/examples/web_scanner/screen_capture_monitor.js
+++ b/examples/web_scanner/screen_capture_monitor.js
@@ -135,6 +135,8 @@ function bindUi() {
   window.addEventListener("pointerup", endRoiDrag);
   window.addEventListener("resize", resizeCanvases);
   els.scanInterval.addEventListener("input", updateScanIntervalLabel);
+  els.matchThreshold.addEventListener("input", updateLiveThresholdMeters);
+  els.cornerThreshold.addEventListener("input", updateLiveThresholdMeters);
   for (const input of [
     els.matchThreshold,
     els.consecutiveMatches,
@@ -445,6 +447,26 @@ function updateLatestResult(data) {
   }
 }
 
+function latestMetricValue(element) {
+  const value = Number.parseFloat(element.textContent);
+  return Number.isFinite(value) ? value : null;
+}
+
+function updateLiveThresholdMeters() {
+  updateThresholdMeter(
+    "match",
+    clamp(Number(els.matchThreshold.value), 0, 1),
+    latestMetricValue(els.latestScore),
+    1,
+  );
+  updateThresholdMeter(
+    "corner",
+    clamp(Number(els.cornerThreshold.value), 0, 0.2),
+    latestMetricValue(els.latestSharpness),
+    0.2,
+  );
+}
+
 function isAcceptedDetection(data) {
   const score = Number(data.score);
   return data.cardPresent
@@ -719,8 +741,7 @@ function applySettingsToInputs() {
   els.cornerThreshold.value = settings.minCornerConfidence.toFixed(2);
   els.groupSecondary.checked = settings.groupBySecondaryId === true;
   els.showRejectedDetections.checked = settings.showRejectedDetections !== false;
-  updateThresholdMeter("match", settings.matchThreshold, null, 1);
-  updateThresholdMeter("corner", settings.minCornerConfidence, null, 0.2);
+  updateLiveThresholdMeters();
 }
 
 function updateScanIntervalLabel() {

--- a/examples/web_scanner/style.css
+++ b/examples/web_scanner/style.css
@@ -336,16 +336,17 @@ h2 {
   top: 0.65rem;
   right: 0.65rem;
   z-index: 3;
-  width: min(26rem, calc(100% - 1.3rem));
+  width: min(38rem, calc(100% - 1.3rem));
   padding: 0.55rem 0.65rem;
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 0.75rem;
   background: rgba(0, 0, 0, 0.62);
   color: #ecffe8;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   line-height: 1.35;
-  white-space: pre-line;
+  overflow: hidden;
+  white-space: pre;
   pointer-events: none;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
Adds the missing playground HTML surface for stable/testing asset channel switching and the match-score live threshold meter markup. The main scanner and screen capture monitor channel/meter support are already present on current main.

Validation: `npm --prefix tests/js test`.