### PR TITLE
Fix compressed model download progress

### DIFF
--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -2206,9 +2206,10 @@ async function boot() {
           const ranges = { detector: [24, 44], embedder: [44, 60], catalog: [60, 96] };
           const [start, end] = ranges[data.stage] ?? [0, 0];
           const percent = start + (end - start) * data.ratio;
+          const validTotal = data.total > 0 && data.loaded <= data.total;
           const note = data.cached
             ? "Cached"
-            : data.total > 0
+            : validTotal
             ? `${formatBytes(data.loaded)} / ${formatBytes(data.total)}`
             : `${formatBytes(data.loaded)} downloaded`;
           const label = {

--- a/examples/web_scanner/scanner.worker.mjs
+++ b/examples/web_scanner/scanner.worker.mjs
@@ -411,13 +411,13 @@ async function fetchWithProgress(url, responseType, expectedTotal, onProgress) {
     loaded += value.length;
     // Fetch streams expose decoded bytes, while Content-Length can describe a
     // compressed HTTP response. Do not present an invalid total to the UI.
-    if (declaredTotal === 0 && total > 0 && loaded > total) {
+    if (total > 0 && loaded > total) {
       total = 0;
     }
     onProgress?.(total > 0 ? loaded / total : 0, loaded, total);
   }
 
-  onProgress?.(1, loaded, total);
+  onProgress?.(1, loaded, loaded);
   const blob = new Blob(chunks);
   if (responseType === "json") {
     return JSON.parse(await blob.text());


### PR DESCRIPTION
GitHub Pages serves the ONNX files with gzip encoding. Fetch streams report decoded bytes, while `Content-Length` can report compressed bytes, producing impossible labels such as `3.0 MB / 2.8 MB`.

This change:

- discards any advertised total once decoded bytes exceed it
- reports the actual decoded byte count as the final total
- defensively avoids fraction formatting when `loaded > total`

Observed responses:

- Fastweb: 3,185,226 decoded bytes; 2,888,775 compressed bytes
- Milo: 5,191,100 decoded bytes; 3,748,840 compressed bytes