### PR TITLE
Improve web scanner startup and testing-channel UX

### DIFF
--- a/examples/web_scanner/README.md
+++ b/examples/web_scanner/README.md
@@ -18,7 +18,8 @@ Catalog v2 is the default:
 
 Append `?catalog=v1` to use the prepared static catalog bundle. This is the
 compatibility path, not the default. `?channel=testing` selects the separately
-published testing model bundle.
+published testing model bundle on the scanner, playground, and screen capture
+monitor. Links between those pages preserve the selected channel.
 
 The standalone [`catalog_v2_example.html`](./catalog_v2_example.html) loads any
 published game catalog and displays its first record.

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -2189,6 +2189,48 @@ async function boot() {
 
   // Wire up init-phase progress messages before posting 'init'.
   const scannerReady = new Promise((resolve, reject) => {
+    const stageProgress = new Map();
+    const bundledCatalogBytes = Object.values(manifest.catalog?.asset_sizes ?? {})
+      .reduce((total, size) => total + (Number.isSafeInteger(size) && size > 0 ? size : 0), 0);
+
+    function displayProgress(data) {
+      const previous = stageProgress.get(data.stage);
+      const rawLoaded = Math.max(0, Number(data.loaded) || 0);
+      const rawTotal = Math.max(0, Number(data.total) || 0);
+      let loaded = rawLoaded;
+      let total = rawTotal;
+      let ratio = Math.max(0, Math.min(1, Number(data.ratio) || 0));
+      let offset = previous?.offset ?? 0;
+
+      // Older workers report each bundled catalog file independently. Combine
+      // those reports so the display does not jump from the embeddings size
+      // back down to the card-ID file size.
+      if (data.stage === "catalog" && catalogMode === "v1" && bundledCatalogBytes > 0) {
+        if (rawTotal === bundledCatalogBytes) {
+          offset = 0;
+        } else if (previous && rawLoaded < previous.rawLoaded) {
+          offset = previous.loaded;
+        }
+        loaded = Math.min(bundledCatalogBytes, offset + rawLoaded);
+        total = bundledCatalogBytes;
+        ratio = loaded / total;
+      }
+
+      // Completion-only events (Catalog v2 currently emits one) do not carry
+      // byte counts. Keep the last useful byte detail rather than flashing 0 B.
+      if (previous && loaded < previous.loaded) {
+        loaded = previous.loaded;
+        total = previous.total;
+      }
+      if (previous) {
+        ratio = Math.max(ratio, previous.ratio);
+      }
+
+      const progress = { loaded, total, ratio, rawLoaded, offset };
+      stageProgress.set(data.stage, progress);
+      return progress;
+    }
+
     function onInitMessage({ data }) {
       if (data.type === "progress") {
         recordBootTrace("worker:progress", data, { debugOnly: data.ratio < 1 });
@@ -2204,19 +2246,24 @@ async function boot() {
           debugLog.info("dewarp ready");
         } else {
           const ranges = { detector: [24, 44], embedder: [44, 60], catalog: [60, 96] };
+          const progress = displayProgress(data);
           const [start, end] = ranges[data.stage] ?? [0, 0];
-          const percent = start + (end - start) * data.ratio;
+          const percent = start + (end - start) * progress.ratio;
           const note = data.cached
             ? "Cached"
-            : data.total > 0
-            ? `${formatBytes(data.loaded)} / ${formatBytes(data.total)}`
-            : `${formatBytes(data.loaded)} downloaded`;
+            : progress.total > 0
+            ? `${formatBytes(progress.loaded)} / ${formatBytes(progress.total)}`
+            : progress.loaded > 0
+            ? `${formatBytes(progress.loaded)} downloaded`
+            : data.ratio >= 1
+            ? "Ready"
+            : "Starting";
           const label = {
             detector: "Loading corner detector",
             embedder: "Loading embedder",
             catalog: "Loading card catalog",
           }[data.stage];
-          setPhase(data.stage, percent, label, note, data.ratio >= 1 ? "done" : "active");
+          setPhase(data.stage, percent, label, note, progress.ratio >= 1 ? "done" : "active");
         }
       } else if (data.type === "ready") {
         recordBootTrace("worker:ready", {

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -2253,7 +2253,11 @@ async function boot() {
   loadingScreen.step("dewarp", "active", "Queued");
   loadingScreen.step("detector", "active", "Queued");
   loadingScreen.step("embedder", "active", "Queued");
-  loadingScreen.step("catalog", "active", "Waiting for models");
+  loadingScreen.step(
+    "catalog",
+    "active",
+    catalogMode === "v2" ? "Downloading and indexing" : "Waiting for models",
+  );
   setText("models-status", "Loading models");
 
   scannerWorker.postMessage({

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -2050,6 +2050,18 @@ function resolveAssetChannel() {
   return Object.hasOwn(ASSET_CHANNELS, requested) ? requested : "stable";
 }
 
+function preserveAssetChannel(channel) {
+  for (const link of document.querySelectorAll("a[data-preserve-channel]")) {
+    const url = new URL(link.href, location.href);
+    if (channel === "testing") {
+      url.searchParams.set("channel", channel);
+    } else {
+      url.searchParams.delete("channel");
+    }
+    link.href = url.href;
+  }
+}
+
 function resolveCatalogMode() {
   const requested = new URLSearchParams(location.search).get("catalog") ?? "v2";
   if (requested !== "v1" && requested !== "v2") {
@@ -2156,6 +2168,7 @@ async function boot() {
   // Load the manifest on the main thread first — it drives both the loading
   // screen text and the worker init message.
   const channel = resolveAssetChannel();
+  preserveAssetChannel(channel);
   const catalogMode = resolveCatalogMode();
   const { assetBasePath, manifest } = await loadManifest(channel);
   const catalogLimit = getCatalogLimitFromQuery();

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -1695,12 +1695,16 @@ class PerformanceOverlay {
     const threads = this.captureState?.numThreads ?? "—";
     const mode = this.captureState?.inferenceMode ?? "—";
     const resultGap = data?.resultGapMs ? formatMs(data.resultGapMs) : "—";
-    const resultFps = data?.resultGapMs ? `${(1000 / data.resultGapMs).toFixed(1)} FPS` : "— FPS";
+    const observedFps = data?.resultGapMs ? (1000 / data.resultGapMs).toFixed(1) : "—";
+    const pipelineFps = timing.totalMs > 0 ? (1000 / timing.totalMs).toFixed(1) : "—";
+    const intervalMs = getScanIntervalMs();
+    const intervalCeiling = intervalMs > 0 ? (1000 / intervalMs).toFixed(1) : "max";
     const score = Number.isFinite(data?.score) ? data.score.toFixed(3) : "—";
     const card = data?.cardPresent ? (data.cornersValid ? "card" : "bad-quad") : "no-card";
     const orientation = data?.orientation ? `  ${data.orientation}` : "";
     this.el.textContent = [
-      `minimum interval ${getScanIntervalMs()}ms  result ${resultGap}  ${resultFps}`,
+      `FPS observed ${observedFps}  pipeline ${pipelineFps}  interval ceiling ${intervalCeiling}`,
+      `minimum interval ${intervalMs}ms  result gap ${resultGap}`,
       `total ${formatMs(timing.totalMs)}  det ${formatMs(timing.detectMs)} (run ${formatMs(timing.detectorRunMs)})`,
       `dew ${formatMs(timing.dewarpMs)} (warp ${formatMs(timing.dewarpWarpMs)})  emb ${formatMs(timing.embedMs)} (run ${formatMs(timing.embedRunMs)})`,
       `prep det ${formatMs(timing.detectorInputMs)}  prep emb ${formatMs(timing.embedInputMs)}  lookup ${formatMs(timing.searchMs)}`,

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -1583,20 +1583,41 @@ function setupCornerConfidenceSlider(scannerWorker = null) {
   slider.addEventListener("input", update);
 }
 
+const thresholdMeterPeaks = new Map();
+
 function updateThresholdMeter(name, threshold, current, maximum) {
   const fill = document.getElementById(`${name}-signal-fill`);
+  const peakMarker = document.getElementById(`${name}-signal-peak`);
   const marker = document.getElementById(`${name}-signal-threshold`);
   const value = document.getElementById(`${name}-signal-value`);
-  if (!fill || !marker || !value) return;
+  if (!fill || !peakMarker || !marker || !value) return;
 
   marker.style.left = `${(Math.min(1, Math.max(0, threshold / maximum)) * 100).toFixed(1)}%`;
-  if (!Number.isFinite(current)) {
-    fill.style.width = "0%";
-    value.textContent = "Current —";
-    return;
+  const now = performance.now();
+  const signal = Number.isFinite(current) ? Math.min(maximum, Math.max(0, current)) : 0;
+  const previous = thresholdMeterPeaks.get(name) ?? {
+    value: 0,
+    holdUntil: 0,
+    updatedAt: now,
+  };
+  let peak = previous.value;
+  let holdUntil = previous.holdUntil;
+  if (signal >= peak) {
+    peak = signal;
+    holdUntil = now + 1200;
+  } else if (now > holdUntil) {
+    peak = Math.max(signal, peak - maximum * ((now - previous.updatedAt) / 2200));
   }
-  fill.style.width = `${(Math.min(1, Math.max(0, current / maximum)) * 100).toFixed(1)}%`;
-  value.textContent = `Current ${current.toFixed(3)}`;
+  thresholdMeterPeaks.set(name, { value: peak, holdUntil, updatedAt: now });
+
+  fill.style.width = `${(signal / maximum * 100).toFixed(1)}%`;
+  peakMarker.style.left = `${(peak / maximum * 100).toFixed(1)}%`;
+  peakMarker.style.opacity = peak > 0 ? "1" : "0";
+  value.textContent = Number.isFinite(current)
+    ? `Current ${current.toFixed(3)} · peak ${peak.toFixed(3)}`
+    : peak > 0
+    ? `Current — · peak ${peak.toFixed(3)}`
+    : "Current —";
 }
 
 function setupMinMatchesSlider() {

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -1,3 +1,5 @@
+import { createProgressTracker } from "./lib/progress.mjs";
+
 // Replaced by the deploy-pages CI workflow with the actual short commit SHA.
 const BUILD_ID = "__BUILD_ID__";
 
@@ -2227,47 +2229,9 @@ async function boot() {
 
   // Wire up init-phase progress messages before posting 'init'.
   const scannerReady = new Promise((resolve, reject) => {
-    const stageProgress = new Map();
     const bundledCatalogBytes = Object.values(manifest.catalog?.asset_sizes ?? {})
       .reduce((total, size) => total + (Number.isSafeInteger(size) && size > 0 ? size : 0), 0);
-
-    function displayProgress(data) {
-      const previous = stageProgress.get(data.stage);
-      const rawLoaded = Math.max(0, Number(data.loaded) || 0);
-      const rawTotal = Math.max(0, Number(data.total) || 0);
-      let loaded = rawLoaded;
-      let total = rawTotal;
-      let ratio = Math.max(0, Math.min(1, Number(data.ratio) || 0));
-      let offset = previous?.offset ?? 0;
-
-      // Older workers report each bundled catalog file independently. Combine
-      // those reports so the display does not jump from the embeddings size
-      // back down to the card-ID file size.
-      if (data.stage === "catalog" && catalogMode === "v1" && bundledCatalogBytes > 0) {
-        if (rawTotal === bundledCatalogBytes) {
-          offset = 0;
-        } else if (previous && rawLoaded < previous.rawLoaded) {
-          offset = previous.loaded;
-        }
-        loaded = Math.min(bundledCatalogBytes, offset + rawLoaded);
-        total = bundledCatalogBytes;
-        ratio = loaded / total;
-      }
-
-      // Completion-only events (Catalog v2 currently emits one) do not carry
-      // byte counts. Keep the last useful byte detail rather than flashing 0 B.
-      if (previous && loaded < previous.loaded) {
-        loaded = previous.loaded;
-        total = previous.total;
-      }
-      if (previous) {
-        ratio = Math.max(ratio, previous.ratio);
-      }
-
-      const progress = { loaded, total, ratio, rawLoaded, offset };
-      stageProgress.set(data.stage, progress);
-      return progress;
-    }
+    const displayProgress = createProgressTracker({ catalogMode, bundledCatalogBytes });
 
     function onInitMessage({ data }) {
       if (data.type === "progress") {

--- a/examples/web_scanner/applet_example.css
+++ b/examples/web_scanner/applet_example.css
@@ -32,6 +32,24 @@ h2 {
 
 p { line-height: 1.55; }
 
+.playground-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.playground-heading nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.playground-heading nav a {
+  color: inherit;
+  font-weight: 700;
+}
+
 code {
   border-radius: 0.35rem;
   padding: 0.1rem 0.3rem;

--- a/examples/web_scanner/applet_example.css
+++ b/examples/web_scanner/applet_example.css
@@ -244,6 +244,19 @@ tr:last-child td { border-bottom: 0; }
   transform: translateX(-1px);
 }
 
+.scan-settings-meter__peak {
+  position: absolute;
+  top: 0.05rem;
+  bottom: 0.05rem;
+  left: 0;
+  width: 2px;
+  background: #fff;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.7);
+  opacity: 0;
+  transform: translateX(-1px);
+  transition: left 80ms linear, opacity 80ms linear;
+}
+
 .scan-settings-meter-value {
   font-size: 0.76rem;
   color: #81796f;

--- a/examples/web_scanner/applet_example.html
+++ b/examples/web_scanner/applet_example.html
@@ -47,7 +47,13 @@
     <div id="effects-layer" aria-hidden="true"></div>
     <main>
       <header>
-        <p class="eyebrow">Candidate API</p>
+        <div class="playground-heading">
+          <p class="eyebrow">Candidate API · <span id="asset-channel">stable assets</span></p>
+          <nav aria-label="Related pages">
+            <a data-preserve-channel href="./">Scanner</a>
+            <a data-preserve-channel href="./screen_capture_monitor.html">Screen capture monitor</a>
+          </nav>
+        </div>
         <h1>Scanner Playground</h1>
         <p>Try preset card handlers, edit the JavaScript, and see how the applet can fit into your own page. This playground keeps everything local in your browser: apply a handler, then scan a card. Need to disable cross-origin isolation for debugging? Open with <code>?coi=0</code>.</p>
       </header>
@@ -59,7 +65,7 @@
             <summary>Scan settings</summary>
             <div class="scan-settings-grid">
               <label class="scan-settings-mic" for="scan-corner-threshold">
-                <span>Corner threshold <span id="scan-corner-threshold-label">0.02</span></span>
+                <span>Minimum corner sharpness <span id="scan-corner-threshold-label">0.02</span></span>
                 <input id="scan-corner-threshold" type="range" min="0" max="0.1" step="0.01" />
                 <span class="scan-settings-meter" aria-hidden="true">
                   <span id="scan-corner-signal-fill" class="scan-settings-meter__fill"></span>

--- a/examples/web_scanner/applet_example.html
+++ b/examples/web_scanner/applet_example.html
@@ -69,6 +69,7 @@
                 <input id="scan-corner-threshold" type="range" min="0" max="0.1" step="0.01" />
                 <span class="scan-settings-meter" aria-hidden="true">
                   <span id="scan-corner-signal-fill" class="scan-settings-meter__fill"></span>
+                  <span id="scan-corner-signal-peak" class="scan-settings-meter__peak"></span>
                   <span id="scan-corner-signal-threshold" class="scan-settings-meter__threshold"></span>
                 </span>
                 <span id="scan-corner-signal-value" class="scan-settings-meter-value">Current 0.00</span>
@@ -78,6 +79,7 @@
                 <span>Match score <span id="scan-match-signal-value">Current —</span></span>
                 <span class="scan-settings-meter" aria-hidden="true">
                   <span id="scan-match-signal-fill" class="scan-settings-meter__fill"></span>
+                  <span id="scan-match-signal-peak" class="scan-settings-meter__peak"></span>
                   <span id="scan-match-signal-threshold" class="scan-settings-meter__threshold"></span>
                 </span>
               </div>

--- a/examples/web_scanner/applet_example.js
+++ b/examples/web_scanner/applet_example.js
@@ -30,6 +30,16 @@ function resolveAssetChannel() {
 
 const assetChannel = resolveAssetChannel();
 const assetBasePath = ASSET_CHANNELS[assetChannel];
+document.getElementById("asset-channel").textContent = `${assetChannel} assets`;
+for (const link of document.querySelectorAll("a[data-preserve-channel]")) {
+  const url = new URL(link.href, location.href);
+  if (assetChannel === "testing") {
+    url.searchParams.set("channel", assetChannel);
+  } else {
+    url.searchParams.delete("channel");
+  }
+  link.href = url.href;
+}
 
 const PRESETS = [
   {

--- a/examples/web_scanner/applet_example.js
+++ b/examples/web_scanner/applet_example.js
@@ -126,9 +126,11 @@ const presetSelect = document.getElementById("preset-code");
 const cornerThresholdInput = document.getElementById("scan-corner-threshold");
 const cornerThresholdLabel = document.getElementById("scan-corner-threshold-label");
 const cornerSignalFill = document.getElementById("scan-corner-signal-fill");
+const cornerSignalPeak = document.getElementById("scan-corner-signal-peak");
 const cornerSignalThreshold = document.getElementById("scan-corner-signal-threshold");
 const cornerSignalValue = document.getElementById("scan-corner-signal-value");
 const matchSignalFill = document.getElementById("scan-match-signal-fill");
+const matchSignalPeak = document.getElementById("scan-match-signal-peak");
 const matchSignalThreshold = document.getElementById("scan-match-signal-threshold");
 const matchSignalValue = document.getElementById("scan-match-signal-value");
 const thresholdInput = document.getElementById("scan-threshold");
@@ -209,27 +211,51 @@ function updateCornerThresholdUi(value) {
   cornerSignalThreshold.style.left = `${(ratio * 100).toFixed(1)}%`;
 }
 
+const signalPeaks = new Map();
+
+function updateSignalMeter(name, current, maximum, fill, peakMarker, value) {
+  const now = performance.now();
+  const signal = Number.isFinite(current) ? clamp(current, 0, maximum) : 0;
+  const previous = signalPeaks.get(name) ?? {
+    value: 0,
+    holdUntil: 0,
+    updatedAt: now,
+  };
+  let peak = previous.value;
+  let holdUntil = previous.holdUntil;
+  if (signal >= peak) {
+    peak = signal;
+    holdUntil = now + 1200;
+  } else if (now > holdUntil) {
+    peak = Math.max(signal, peak - maximum * ((now - previous.updatedAt) / 2200));
+  }
+  signalPeaks.set(name, { value: peak, holdUntil, updatedAt: now });
+
+  fill.style.width = `${(signal / maximum * 100).toFixed(1)}%`;
+  peakMarker.style.left = `${(peak / maximum * 100).toFixed(1)}%`;
+  peakMarker.style.opacity = peak > 0 ? "1" : "0";
+  value.textContent = Number.isFinite(current)
+    ? `Current ${current.toFixed(3)} · peak ${peak.toFixed(3)}`
+    : peak > 0
+    ? `Current — · peak ${peak.toFixed(3)}`
+    : "Current —";
+}
+
 function updateCornerSignal(confidence) {
-  const raw = Math.max(0, Number(confidence) || 0);
-  const current = clamp(raw, 0, MAX_GUI_CORNER_CONFIDENCE);
-  const ratio = current / MAX_GUI_CORNER_CONFIDENCE;
-  cornerSignalFill.style.width = `${(ratio * 100).toFixed(1)}%`;
-  cornerSignalValue.textContent = raw > MAX_GUI_CORNER_CONFIDENCE
-    ? `Current ${MAX_GUI_CORNER_CONFIDENCE.toFixed(2)}+`
-    : `Current ${current.toFixed(2)}`;
+  updateSignalMeter(
+    "corner",
+    Number(confidence),
+    MAX_GUI_CORNER_CONFIDENCE,
+    cornerSignalFill,
+    cornerSignalPeak,
+    cornerSignalValue,
+  );
 }
 
 function updateMatchSignal(score) {
   const threshold = clamp(Number(thresholdInput.value), 0, 1);
   matchSignalThreshold.style.left = `${(threshold * 100).toFixed(1)}%`;
-  if (!Number.isFinite(score)) {
-    matchSignalFill.style.width = "0%";
-    matchSignalValue.textContent = "Current —";
-    return;
-  }
-  const current = clamp(score, 0, 1);
-  matchSignalFill.style.width = `${(current * 100).toFixed(1)}%`;
-  matchSignalValue.textContent = `Current ${current.toFixed(3)}`;
+  updateSignalMeter("match", score, 1, matchSignalFill, matchSignalPeak, matchSignalValue);
 }
 
 function scanSettingsFromInputs() {

--- a/examples/web_scanner/index.html
+++ b/examples/web_scanner/index.html
@@ -220,7 +220,7 @@
               <span class="toggle-row__label">Show scan timing overlay</span>
               <input type="checkbox" id="perf-overlay-toggle" class="toggle-row__input" />
             </label>
-            <p class="capture-hint">Shows detector, dewarp, embed, lookup, thread, and memory estimates in the camera corner. You can also enable it with <code>?fps=1</code>.</p>
+            <p class="capture-hint">Shows observed and pipeline FPS plus detector, dewarp, embed, lookup, thread, and memory estimates in the camera corner. You can also enable it with <code>?fps=1</code>.</p>
           </section>
 
           <section class="panel panel--nested">

--- a/examples/web_scanner/index.html
+++ b/examples/web_scanner/index.html
@@ -250,8 +250,8 @@
           <section class="panel panel--nested">
             <header class="panel-header">
               <div>
-                <p class="section-kicker">Recognition</p>
-                <h2>Match Threshold</h2>
+                <p class="section-kicker">Detector and recognition</p>
+                <h2>Detection Thresholds</h2>
               </div>
             </header>
             <label class="slider-row" for="match-score-slider">

--- a/examples/web_scanner/index.html
+++ b/examples/web_scanner/index.html
@@ -263,6 +263,7 @@
               min="0.40" max="0.85" step="0.01" value="0.50" />
             <div class="threshold-meter" aria-live="polite">
               <span class="threshold-meter__fill" id="match-score-signal-fill"></span>
+              <span class="threshold-meter__peak" id="match-score-signal-peak"></span>
               <span class="threshold-meter__threshold" id="match-score-signal-threshold"></span>
             </div>
             <p class="threshold-meter__value" id="match-score-signal-value">Current —</p>
@@ -276,6 +277,7 @@
               min="0" max="0.10" step="0.01" value="0.02" />
             <div class="threshold-meter" aria-live="polite">
               <span class="threshold-meter__fill" id="corner-confidence-signal-fill"></span>
+              <span class="threshold-meter__peak" id="corner-confidence-signal-peak"></span>
               <span class="threshold-meter__threshold" id="corner-confidence-signal-threshold"></span>
             </div>
             <p class="threshold-meter__value" id="corner-confidence-signal-value">Current —</p>

--- a/examples/web_scanner/index.html
+++ b/examples/web_scanner/index.html
@@ -112,8 +112,8 @@
             <button class="icon-button icon-button--debug" id="debug-toggle" type="button" aria-label="Show debug panel" aria-expanded="false">
               Debug
             </button>
-            <button class="icon-button icon-button--gear" id="settings-toggle" type="button" aria-label="Toggle settings">
-              ⚙
+            <button class="icon-button icon-button--gear" id="settings-toggle" type="button" aria-label="Open scanner settings">
+              <span aria-hidden="true">⚙</span> Settings
             </button>
           </div>
         </header>
@@ -231,7 +231,8 @@
               </div>
             </header>
             <p class="capture-hint">Watch a shared tab, window, or screen, crop to a region of interest, and emit card events for overlays or CSV/JSONL export.</p>
-            <a class="action-button action-button--block" href="./screen_capture_monitor.html">▶ Open Screen Capture Monitor</a>
+            <a class="action-button action-button--block" data-preserve-channel href="./screen_capture_monitor.html">▶ Open Screen Capture Monitor</a>
+            <a class="action-button action-button--block" data-preserve-channel href="./applet_example.html">▶ Open Scanner Playground</a>
           </section>
 
           <section class="panel panel--nested">

--- a/examples/web_scanner/lib/progress.mjs
+++ b/examples/web_scanner/lib/progress.mjs
@@ -1,0 +1,40 @@
+export function createProgressTracker({ catalogMode, bundledCatalogBytes = 0 } = {}) {
+  const stages = new Map();
+
+  return function trackProgress(data) {
+    const previous = stages.get(data.stage);
+    const rawLoaded = Math.max(0, Number(data.loaded) || 0);
+    const rawTotal = Math.max(0, Number(data.total) || 0);
+    let loaded = rawLoaded;
+    let total = rawTotal;
+    let ratio = Math.max(0, Math.min(1, Number(data.ratio) || 0));
+    let offset = previous?.offset ?? 0;
+
+    // Older workers report each bundled catalog file independently. Combine
+    // those reports into the manifest's authoritative aggregate size.
+    if (data.stage === "catalog" && catalogMode === "v1" && bundledCatalogBytes > 0) {
+      if (rawTotal === bundledCatalogBytes) {
+        offset = 0;
+      } else if (previous && rawLoaded < previous.rawLoaded) {
+        offset = previous.loaded;
+      }
+      loaded = Math.min(bundledCatalogBytes, offset + rawLoaded);
+      total = bundledCatalogBytes;
+      ratio = loaded / total;
+    }
+
+    // Keep completion-only events from erasing useful byte details, and keep
+    // every stage monotonic if messages arrive late or restart at zero.
+    if (previous && loaded < previous.loaded) {
+      loaded = previous.loaded;
+      total = previous.total;
+    }
+    if (previous) {
+      ratio = Math.max(ratio, previous.ratio);
+    }
+
+    const progress = { loaded, total, ratio, rawLoaded, offset };
+    stages.set(data.stage, progress);
+    return progress;
+  };
+}

--- a/examples/web_scanner/scanner.worker.mjs
+++ b/examples/web_scanner/scanner.worker.mjs
@@ -601,6 +601,12 @@ class WorkerRuntime {
 
   async load(onStage) {
     const version = this.manifest.version;
+    const catalogPromise = this.catalogMode === "v2"
+      ? this.loadCatalogV2(onStage).then(
+        () => null,
+        (error) => error,
+      )
+      : null;
     // Use per-model content hashes as cache keys when available so that a new
     // model weight file (same filename, different content) always busts the
     // IndexedDB entry, even if the bundle version string hasn't changed.
@@ -608,18 +614,20 @@ class WorkerRuntime {
     const modelSizes = this.manifest.model_sizes ?? {};
     const detectorVersion = hashes[this.detectorConfig.modelKey] ?? version;
     const embedderVersion = hashes.milo       ?? version;
-    const detectorBuffer = await fetchBufferCached(
-      `${this.assetBasePath}/${this.manifest.models[this.detectorConfig.modelKey]}`,
-      detectorVersion,
-      modelSizes[this.detectorConfig.modelKey],
-      (ratio, loaded, total, cached) => onStage?.("detector", ratio, loaded, total, cached),
-    );
-    const embedderBuffer = await fetchBufferCached(
-      `${this.assetBasePath}/${this.manifest.models.milo}`,
-      embedderVersion,
-      modelSizes.milo,
-      (ratio, loaded, total, cached) => onStage?.("embedder", ratio, loaded, total, cached),
-    );
+    const [detectorBuffer, embedderBuffer] = await Promise.all([
+      fetchBufferCached(
+        `${this.assetBasePath}/${this.manifest.models[this.detectorConfig.modelKey]}`,
+        detectorVersion,
+        modelSizes[this.detectorConfig.modelKey],
+        (ratio, loaded, total, cached) => onStage?.("detector", ratio, loaded, total, cached),
+      ),
+      fetchBufferCached(
+        `${this.assetBasePath}/${this.manifest.models.milo}`,
+        embedderVersion,
+        modelSizes.milo,
+        (ratio, loaded, total, cached) => onStage?.("embedder", ratio, loaded, total, cached),
+      ),
+    ]);
 
     // Use as many threads as the device has cores, capped at 4.
     // NOTE: multi-threaded WASM requires SharedArrayBuffer / COOP+COEP headers.
@@ -648,7 +656,8 @@ class WorkerRuntime {
     this.inputNames.embedder = this.embedder.inputNames[0];
 
     if (this.catalogMode === "v2") {
-      await this.loadCatalogV2(onStage);
+      const catalogError = await catalogPromise;
+      if (catalogError) throw catalogError;
       return;
     }
 

--- a/examples/web_scanner/screen_capture_monitor.css
+++ b/examples/web_scanner/screen_capture_monitor.css
@@ -416,6 +416,19 @@ input[type="range"] {
   transform: translateX(-1px);
 }
 
+.threshold-meter__peak {
+  position: absolute;
+  top: 0.05rem;
+  bottom: 0.05rem;
+  left: 0;
+  width: 2px;
+  background: #fff;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  transform: translateX(-1px);
+  transition: left 100ms linear, opacity 100ms linear;
+}
+
 .threshold-meter__value {
   color: #c8bbab;
   font-size: 0.76rem;

--- a/examples/web_scanner/screen_capture_monitor.html
+++ b/examples/web_scanner/screen_capture_monitor.html
@@ -57,11 +57,12 @@
               <div><dt id="version-detector-label">Detector</dt><dd id="version-cornelius">loading…</dd></div>
               <div><dt>Milo</dt><dd id="version-milo">loading…</dd></div>
               <div><dt>Catalog</dt><dd id="version-catalog">loading…</dd></div>
+              <div><dt>Channel</dt><dd id="version-channel">stable</dd></div>
             </dl>
           </aside>
           <nav class="hero-links" aria-label="Related pages">
-            <a href="./">Scanner</a>
-            <a href="./applet_example.html">Playground</a>
+            <a data-preserve-channel href="./">Scanner</a>
+            <a data-preserve-channel href="./applet_example.html">Playground</a>
             <a href="./screen_capture_overlay.html" target="_blank" rel="noopener noreferrer">Overlay</a>
           </nav>
         </div>
@@ -150,7 +151,7 @@
               <input id="scan-interval" type="range" min="0" max="2500" step="50" value="500" />
             </label>
             <label>
-              Corner threshold
+              Minimum corner sharpness
               <input id="corner-threshold" type="number" min="0" max="0.2" step="0.01" value="0.02" />
               <span class="threshold-meter" aria-live="polite">
                 <span class="threshold-meter__fill" id="corner-signal-fill"></span>

--- a/examples/web_scanner/screen_capture_monitor.html
+++ b/examples/web_scanner/screen_capture_monitor.html
@@ -138,6 +138,7 @@
               <input id="match-threshold" type="number" min="0" max="1" step="0.01" value="0.50" />
               <span class="threshold-meter" aria-live="polite">
                 <span class="threshold-meter__fill" id="match-signal-fill"></span>
+                <span class="threshold-meter__peak" id="match-signal-peak"></span>
                 <span class="threshold-meter__threshold" id="match-signal-threshold"></span>
               </span>
               <span class="threshold-meter__value" id="match-signal-value">Current —</span>
@@ -155,6 +156,7 @@
               <input id="corner-threshold" type="number" min="0" max="0.2" step="0.01" value="0.02" />
               <span class="threshold-meter" aria-live="polite">
                 <span class="threshold-meter__fill" id="corner-signal-fill"></span>
+                <span class="threshold-meter__peak" id="corner-signal-peak"></span>
                 <span class="threshold-meter__threshold" id="corner-signal-threshold"></span>
               </span>
               <span class="threshold-meter__value" id="corner-signal-value">Current —</span>

--- a/examples/web_scanner/screen_capture_monitor.js
+++ b/examples/web_scanner/screen_capture_monitor.js
@@ -39,6 +39,7 @@ const els = {
   versionCornelius: document.getElementById("version-cornelius"),
   versionMilo: document.getElementById("version-milo"),
   versionCatalog: document.getElementById("version-catalog"),
+  versionChannel: document.getElementById("version-channel"),
   roiBox: document.getElementById("roi-box"),
   stageStatus: document.getElementById("stage-status"),
   workerStatus: document.getElementById("worker-status"),
@@ -107,6 +108,17 @@ function resolveAssetChannel() {
 init();
 
 async function init() {
+  const assetChannel = resolveAssetChannel();
+  els.versionChannel.textContent = assetChannel;
+  for (const link of document.querySelectorAll("a[data-preserve-channel]")) {
+    const url = new URL(link.href, location.href);
+    if (assetChannel === "testing") {
+      url.searchParams.set("channel", assetChannel);
+    } else {
+      url.searchParams.delete("channel");
+    }
+    link.href = url.href;
+  }
   applySettingsToInputs();
   applyRoiToBox();
   bindUi();

--- a/examples/web_scanner/screen_capture_monitor.js
+++ b/examples/web_scanner/screen_capture_monitor.js
@@ -55,9 +55,11 @@ const els = {
   scanIntervalValue: document.getElementById("scan-interval-value"),
   cornerThreshold: document.getElementById("corner-threshold"),
   matchSignalFill: document.getElementById("match-signal-fill"),
+  matchSignalPeak: document.getElementById("match-signal-peak"),
   matchSignalThreshold: document.getElementById("match-signal-threshold"),
   matchSignalValue: document.getElementById("match-signal-value"),
   cornerSignalFill: document.getElementById("corner-signal-fill"),
+  cornerSignalPeak: document.getElementById("corner-signal-peak"),
   cornerSignalThreshold: document.getElementById("corner-signal-threshold"),
   cornerSignalValue: document.getElementById("corner-signal-value"),
   groupSecondary: document.getElementById("group-secondary"),
@@ -465,20 +467,40 @@ function isAcceptedDetection(data) {
     && score >= settings.matchThreshold;
 }
 
+const thresholdMeterPeaks = new Map();
+
 function updateThresholdMeter(name, threshold, current, maximum) {
   const fill = els[`${name}SignalFill`];
+  const peakMarker = els[`${name}SignalPeak`];
   const marker = els[`${name}SignalThreshold`];
   const value = els[`${name}SignalValue`];
   const thresholdRatio = clamp(threshold / maximum, 0, 1);
   marker.style.left = `${(thresholdRatio * 100).toFixed(1)}%`;
-  if (!Number.isFinite(current)) {
-    fill.style.width = "0%";
-    value.textContent = "Current —";
-    return;
+  const now = performance.now();
+  const signal = Number.isFinite(current) ? clamp(current, 0, maximum) : 0;
+  const previous = thresholdMeterPeaks.get(name) ?? {
+    value: 0,
+    holdUntil: 0,
+    updatedAt: now,
+  };
+  let peak = previous.value;
+  let holdUntil = previous.holdUntil;
+  if (signal >= peak) {
+    peak = signal;
+    holdUntil = now + 1200;
+  } else if (now > holdUntil) {
+    peak = Math.max(signal, peak - maximum * ((now - previous.updatedAt) / 2200));
   }
-  const currentRatio = clamp(current / maximum, 0, 1);
-  fill.style.width = `${(currentRatio * 100).toFixed(1)}%`;
-  value.textContent = `Current ${current.toFixed(3)}`;
+  thresholdMeterPeaks.set(name, { value: peak, holdUntil, updatedAt: now });
+
+  fill.style.width = `${(signal / maximum * 100).toFixed(1)}%`;
+  peakMarker.style.left = `${(peak / maximum * 100).toFixed(1)}%`;
+  peakMarker.style.opacity = peak > 0 ? "1" : "0";
+  value.textContent = Number.isFinite(current)
+    ? `Current ${current.toFixed(3)} · peak ${peak.toFixed(3)}`
+    : peak > 0
+    ? `Current — · peak ${peak.toFixed(3)}`
+    : "Current —";
 }
 
 function candidateFromResult(data) {

--- a/examples/web_scanner/style.css
+++ b/examples/web_scanner/style.css
@@ -192,9 +192,11 @@ body[data-loading="true"] .loading-screen {
 }
 
 .icon-button--gear {
-  font-size: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   line-height: 1;
-  padding: 0.35rem 0.5rem;
+  padding: 0.5rem 0.65rem;
 }
 
 .camera-shell {

--- a/examples/web_scanner/style.css
+++ b/examples/web_scanner/style.css
@@ -338,7 +338,7 @@ h2 {
   top: 0.65rem;
   right: 0.65rem;
   z-index: 3;
-  width: min(26rem, calc(100% - 1.3rem));
+  width: min(34rem, calc(100% - 1.3rem));
   padding: 0.55rem 0.65rem;
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 0.75rem;
@@ -347,7 +347,8 @@ h2 {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.7rem;
   line-height: 1.35;
-  white-space: pre-line;
+  overflow-x: auto;
+  white-space: pre;
   pointer-events: none;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
 }

--- a/examples/web_scanner/style.css
+++ b/examples/web_scanner/style.css
@@ -692,6 +692,19 @@ dd {
   transform: translateX(-1px);
 }
 
+.threshold-meter__peak {
+  position: absolute;
+  top: 0.06rem;
+  bottom: 0.06rem;
+  left: 0;
+  width: 2px;
+  background: #fff;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.65);
+  opacity: 0;
+  transform: translateX(-1px);
+  transition: left 100ms linear, opacity 100ms linear;
+}
+
 .threshold-meter__value {
   margin: 0.3rem 0 0;
   color: var(--muted, #665f56);

--- a/examples/web_scanner/style.css
+++ b/examples/web_scanner/style.css
@@ -338,7 +338,7 @@ h2 {
   top: 0.65rem;
   right: 0.65rem;
   z-index: 3;
-  width: min(34rem, calc(100% - 1.3rem));
+  width: min(42rem, calc(100vw - 1.3rem));
   padding: 0.55rem 0.65rem;
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: 0.75rem;

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "scripts": {
-    "test": "node --input-type=module --check < ../../examples/web_scanner/app.js && node --check ../../examples/web_scanner/scanner.worker.mjs && node --check ../../examples/web_scanner/lib/collectorvision-catalog-v2.mjs && node test_catalog_v2.mjs && node test_pipeline.mjs"
+    "test": "node --input-type=module --check < ../../examples/web_scanner/app.js && node --check ../../examples/web_scanner/scanner.worker.mjs && node --check ../../examples/web_scanner/lib/collectorvision-catalog-v2.mjs && node test_progress.mjs && node test_catalog_v2.mjs && node test_pipeline.mjs"
   },
   "dependencies": {
     "canvas": "^2.11.2",

--- a/tests/js/test_progress.mjs
+++ b/tests/js/test_progress.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+
+import { createProgressTracker } from "../../examples/web_scanner/lib/progress.mjs";
+
+const EMBEDDINGS_BYTES = 28_086_016;
+const CARD_IDS_BYTES = 4_408_130;
+const ORACLE_IDS_BYTES = 4_388_440;
+const CATALOG_BYTES = EMBEDDINGS_BYTES + CARD_IDS_BYTES + ORACLE_IDS_BYTES;
+
+function progress(stage, loaded, total, ratio = total > 0 ? loaded / total : 0) {
+  return { stage, loaded, total, ratio };
+}
+
+{
+  const track = createProgressTracker({
+    catalogMode: "v1",
+    bundledCatalogBytes: CATALOG_BYTES,
+  });
+  const updates = [
+    progress("catalog", 0, EMBEDDINGS_BYTES),
+    progress("catalog", EMBEDDINGS_BYTES, EMBEDDINGS_BYTES),
+    progress("catalog", 0, CARD_IDS_BYTES),
+    progress("catalog", CARD_IDS_BYTES, CARD_IDS_BYTES),
+    progress("catalog", 0, ORACLE_IDS_BYTES),
+    progress("catalog", ORACLE_IDS_BYTES, ORACLE_IDS_BYTES),
+  ].map(track);
+
+  assert.deepEqual(
+    updates.map(({ loaded }) => loaded),
+    [
+      0,
+      EMBEDDINGS_BYTES,
+      EMBEDDINGS_BYTES,
+      EMBEDDINGS_BYTES + CARD_IDS_BYTES,
+      EMBEDDINGS_BYTES + CARD_IDS_BYTES,
+      CATALOG_BYTES,
+    ],
+  );
+  assert.ok(updates.every(({ total }) => total === CATALOG_BYTES));
+  assert.ok(updates.every((update, index) => index === 0 || update.ratio >= updates[index - 1].ratio));
+}
+
+{
+  const track = createProgressTracker({
+    catalogMode: "v1",
+    bundledCatalogBytes: CATALOG_BYTES,
+  });
+  const updates = [
+    progress("catalog", EMBEDDINGS_BYTES, CATALOG_BYTES),
+    progress("catalog", EMBEDDINGS_BYTES + CARD_IDS_BYTES, CATALOG_BYTES),
+    progress("catalog", CATALOG_BYTES, CATALOG_BYTES),
+  ].map(track);
+
+  assert.deepEqual(updates.map(({ loaded }) => loaded), [
+    EMBEDDINGS_BYTES,
+    EMBEDDINGS_BYTES + CARD_IDS_BYTES,
+    CATALOG_BYTES,
+  ]);
+}
+
+{
+  const track = createProgressTracker();
+  track(progress("catalog", 12_000, 20_000, 0.6));
+  const completed = track(progress("catalog", 0, 0, 1));
+
+  assert.equal(completed.loaded, 12_000);
+  assert.equal(completed.total, 20_000);
+  assert.equal(completed.ratio, 1);
+}
+
+console.log("Catalog progress regression tests passed");


### PR DESCRIPTION
## Summary
- start Catalog v2 loading immediately instead of after both ONNX sessions compile
- download detector and embedder model weights concurrently
- keep multipart loading byte progress monotonic
- support and visibly identify `?channel=testing` in the scanner playground and screen capture monitor
- preserve the selected channel when navigating between web tools
- expose the main scanner Settings button clearly and use consistent Minimum corner sharpness labels

The two ONNX sessions are still compiled sequentially to avoid increasing peak memory pressure on mobile browsers.

## Why startup appeared hung
There are no artificial startup delays. A cold MTG Catalog v2 load currently downloads about 35 MB compressed (26.0 MB embeddings plus 8.9 MB records), verifies checksums, decompresses and parses 111k records, applies deltas, and writes an IndexedDB snapshot.

## Validation
- JavaScript syntax checks for scanner, playground, monitor, and worker
- Catalog v2 tests: 65 passed