### PR TITLE
Expose stable and testing scanner channels

### DIFF
--- a/examples/web_scanner/README.md
+++ b/examples/web_scanner/README.md
@@ -20,6 +20,9 @@ Append `?catalog=v1` to use the prepared static catalog bundle. This is the
 compatibility path, not the default. `?channel=testing` selects the separately
 published testing model bundle.
 
+The active channel is shown next to the app title and links to the other channel,
+making stable/testing detector comparisons explicit.
+
 The standalone [`catalog_v2_example.html`](./catalog_v2_example.html) loads any
 published game catalog and displays its first record.
 

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -3,8 +3,8 @@ const BUILD_ID = "__BUILD_ID__";
 
 const GITHUB_REPO = "HanClinto/CollectorVision";
 const ASSET_CHANNELS = {
-  stable: "./assets",
-  testing: "./testing/assets",
+  stable: new URL("./assets", import.meta.url).href,
+  testing: new URL("./testing/assets", import.meta.url).href,
 };
 
 // DETECTOR_SIZE is kept here for the capture-bundle debug export.

--- a/examples/web_scanner/app.js
+++ b/examples/web_scanner/app.js
@@ -2046,8 +2046,38 @@ function createScannerLoop(
 }
 
 function resolveAssetChannel() {
-  const requested = new URLSearchParams(location.search).get("channel") ?? "stable";
-  return Object.hasOwn(ASSET_CHANNELS, requested) ? requested : "stable";
+  const requested = (
+    new URLSearchParams(location.search).get("channel") ?? "stable"
+  ).trim().toLowerCase();
+  if (!Object.hasOwn(ASSET_CHANNELS, requested)) {
+    throw new Error(
+      `Unknown asset channel ${requested}. Expected one of: ${Object.keys(ASSET_CHANNELS).join(", ")}.`,
+    );
+  }
+  return requested;
+}
+
+function channelUrl(channel) {
+  const params = new URLSearchParams(location.search);
+  params.delete("v");
+  if (channel === "stable") {
+    params.delete("channel");
+  } else {
+    params.set("channel", channel);
+  }
+  const query = params.toString();
+  return `${location.pathname}${query ? `?${query}` : ""}${location.hash}`;
+}
+
+function setupChannelSwitch(channel, detectorFamily) {
+  const nextChannel = channel === "stable" ? "testing" : "stable";
+  const switcher = document.getElementById("channel-switch");
+  switcher.textContent = channel;
+  switcher.href = channelUrl(nextChannel);
+  switcher.title = `Using ${detectorFamily}; switch to ${nextChannel} assets`;
+  switcher.setAttribute("aria-label", `Using ${channel} assets; switch to ${nextChannel}`);
+  switcher.classList.toggle("channel-badge--testing", channel === "testing");
+  setText("settings-channel", `${channel} · ${detectorFamily}`);
 }
 
 function resolveCatalogMode() {
@@ -2175,6 +2205,7 @@ async function boot() {
     debugLog.warn("debug catalog limit active", `${catalogLimit} rows`);
   }
   const detectorFamily = manifest.detector?.family ?? "cornelius";
+  setupChannelSwitch(channel, detectorFamily);
   setText("settings-detector-name", `Detector (${detectorFamily})`);
   setText("settings-detector-hash", modelVersionLabel(detectorModelKey(manifest), manifest));
   setText("settings-milo-hash", modelVersionLabel("milo", manifest));

--- a/examples/web_scanner/index.html
+++ b/examples/web_scanner/index.html
@@ -107,7 +107,10 @@
     <div class="app-shell">
       <main class="page">
         <header class="app-bar">
-          <h1 class="app-bar__title">CollectorVision</h1>
+          <div class="app-bar__identity">
+            <h1 class="app-bar__title">CollectorVision</h1>
+            <a class="channel-badge" id="channel-switch" href="./" aria-label="Switch asset channel">Stable</a>
+          </div>
           <div class="app-bar__actions">
             <button class="icon-button icon-button--debug" id="debug-toggle" type="button" aria-label="Show debug panel" aria-expanded="false">
               Debug
@@ -312,6 +315,10 @@
           </section>
 
           <dl class="settings-grid">
+            <div>
+              <dt>Asset channel</dt>
+              <dd id="settings-channel">—</dd>
+            </div>
             <div>
               <dt>Build</dt>
               <dd id="settings-build">—</dd>

--- a/examples/web_scanner/style.css
+++ b/examples/web_scanner/style.css
@@ -169,6 +169,34 @@ body[data-loading="true"] .loading-screen {
   font-weight: 600;
 }
 
+.app-bar__identity {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.channel-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.75rem;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  color: inherit;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.channel-badge--testing {
+  border-color: #ffd166;
+  background: #ffd166;
+  color: #332600;
+}
+
 .app-bar__actions {
   display: flex;
   gap: 0.55rem;


### PR DESCRIPTION
Supersedes #48 after its branch was rewritten while fixing manifest URL resolution.

- adds an explicit stable/testing channel badge and switcher
- preserves diagnostic query parameters while switching
- displays the active channel and detector family
- rejects unknown channel names
- resolves asset roots from `import.meta.url`, preventing document-path-dependent 404s for the testing manifest

Validated locally: Ruff, 85 offline Python tests, and scanner JavaScript syntax checks pass.